### PR TITLE
refactor: generalize library — remove oral-pipeline specifics

### DIFF
--- a/.claude/rules/steering-potentials.md
+++ b/.claude/rules/steering-potentials.md
@@ -2,5 +2,6 @@
 
 Boltz-2 steering potentials MUST be enabled by default.
 
-Without them, 30-60% of predictions produce physically impossible structures
-with severe steric clashes.
+Without them, a substantial fraction of predictions carry severe steric
+clashes. See the Boltz-2 paper / docs on `use_potentials` for the underlying
+discussion.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ biolab_runners/
 - **Input:** Receptor sequence + peptide sequence (strings), optional pocket constraints
 - **Output:** `PredictionResult` with structure path, confidence scores, quality gate
 - **Quality gate:** PASS / CONDITIONAL / FAIL based on ipTM, pLDDT, clash thresholds
-- **Steering potentials:** Always enabled by default — without them, 30-60% of predictions have physically impossible structures
+- **Steering potentials:** Always enabled by default — without them a substantial fraction of predictions carry severe steric clashes (see the Boltz-2 paper / docs on `use_potentials`)
 - **pLDDT rescaling:** Boltz-2 v2 reports 0-1 scale; parser auto-detects and rescales to 0-100
 - **MSA caching:** Receptor MSA CSV reused across predictions against the same target
 
@@ -42,8 +42,8 @@ biolab_runners/
 - **Input:** `OpenMMConfig` with receptor/peptide PDB paths, simulation parameters
 - **Output:** `SimulationResult` with trajectory DCD, energy CSV, state XML
 - **Force fields:** CHARMM36m protein, TIP3P water, dodecahedral solvent box
-- **Buffer environment:** Configurable via `OpenMMConfig` fields or the `saliva` / `physiological` / `gastric` / `intestinal` preset classmethods. Field defaults are saliva-like (140 mM NaCl + 1.4 mM CaCl2 + 0.5 mM KH2PO4, pH 6.2, 310 K) for backward compatibility with OralBiome-AMP
-- **Early abort:** 5ns/10ns checkpoint — if peptide dissociates (PBC-corrected RMSD > 2x threshold), abort
+- **Buffer environment:** Configurable via `OpenMMConfig` fields or the `physiological` / `saliva` / `gastric` / `intestinal` preset classmethods. Field defaults are physiological PBS-like (150 mM NaCl, pH 7.4, 310 K)
+- **Early abort:** 5 ns / 10 ns checkpoint — if peptide dissociates (PBC-corrected Cα RMSD > 2 × `config.target_irmsd_threshold_a`), abort. Threshold is per-system and defaults to 3.5 Å — override for tighter/looser gating
 - **Resume safety:** Always load original topology.pdb — re-solvating produces different water counts
 - **Restraint force on resume:** Must add restraint force (k=0) to system even on resume, or loadState() fails
 - **PBC correction:** All RMSD checks use minimum image convention — without it, RMSD can be ~100A

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -6,7 +6,7 @@ Patterns and incidents discovered during development. Use this as a lookup befor
 
 **Context:** Boltz2Runner structure predictions.
 
-**Problem:** Without steering potentials, 30-60% of predictions produce physically impossible structures with severe steric clashes.
+**Problem:** Without steering potentials, a substantial fraction of predictions carry severe steric clashes (see the Boltz-2 paper's `use_potentials` discussion).
 
 **Solution:** Steering potentials always enabled by default. Promoted to `.claude/rules/steering-potentials.md`.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ from biolab_runners.boltz2 import Boltz2Runner, Boltz2Config
 config = Boltz2Config(
     accelerator="gpu",
     recycling_steps=3,
-    use_potentials=True,  # Reduces steric clashes from ~36% to ~0%
+    use_potentials=True,  # Steering potentials — substantially reduces clashes
 )
 
 # Run prediction
@@ -57,7 +57,7 @@ runner = Boltz2Runner(config)
 result = runner.predict_complex(
     receptor_sequence="MVKLTAEG...",
     peptide_sequence="RWKLFKKIEK",
-    name="GtfB_PEP001",
+    name="demo_complex",
     output_dir=Path("results/predictions"),
 )
 
@@ -99,13 +99,14 @@ from biolab_runners.openmm import OpenMMRunner, OpenMMConfig
 config = OpenMMConfig(
     receptor_pdb="receptor.pdb",
     peptide_pdb="peptide.pdb",
-    output_dir="results/md/GtfB/PEP001",
-    target="GtfB",
+    output_dir="results/md/demo",
+    target="demo",
     peptide_id="PEP001",
-    production_ns=100.0,         # 100 ns production run
-    temperature_k=310.0,         # 37 C (body temperature)
-    protein_ff="charmm36m",      # Force field
-    openmm_platform="OpenCL",    # GPU platform
+    production_ns=100.0,            # 100 ns production run
+    temperature_k=310.0,            # 37 C (body temperature)
+    protein_ff="charmm36m",         # Force field
+    openmm_platform="OpenCL",       # GPU platform
+    target_irmsd_threshold_a=3.5,   # Early-abort reference (per-system)
 )
 
 # Run simulation
@@ -177,29 +178,20 @@ Predictions are automatically classified:
 
 The MD runner checks peptide stability at 5 ns and 10 ns:
 
-- **5 ns check:** Peptide Ca RMSD vs post-equilibration reference. Abort if > 2x target iRMSD threshold.
-- **10 ns check:** RMSD slope between 5-10 ns. Abort if > 0.05 A/ns (drift).
+- **5 ns check:** Peptide Cα RMSD vs post-equilibration reference. Abort if it exceeds `2 × config.target_irmsd_threshold_a`.
+- **10 ns check:** RMSD slope between 5–10 ns. Abort if > 0.05 Å/ns (drift).
 
-Per-target thresholds (expert-calibrated):
-
-| Target | iRMSD Threshold | Abort Threshold |
-|--------|----------------|-----------------|
-| FadA | 3.0 A | 6.0 A |
-| FimA | 3.0 A | 6.0 A |
-| HmuY | 3.5 A | 7.0 A |
-| VicK | 3.5 A | 7.0 A |
-| SpaP | 4.0 A | 8.0 A |
-| GtfB | 4.0 A | 8.0 A |
+`target_irmsd_threshold_a` defaults to 3.5 Å, which is a reasonable mid-range value for peptide-protein complexes. Tighter binders (small pockets, rigid peptides) justify lower values; floppier binders justify higher values. Set it per system rather than relying on the default — binding-site geometry varies and there is no universal threshold.
 
 ## Equilibration Protocol
 
 3-stage protocol for peptide-protein complexes:
 
-1. **NVT 100 ps** — Strong backbone restraints (k=1000 kJ/mol/nm^2)
-2. **NPT 100 ps** — Reduced restraints (k=100 kJ/mol/nm^2)
-3. **NPT 200 ps** — Gradual ramp (100->0) + 100 ps unrestrained
+1. **NVT 100 ps** — Strong backbone restraints (k=1000 kJ/mol/nm²)
+2. **NPT 100 ps** — Reduced restraints (k=100 kJ/mol/nm²)
+3. **NPT 200 ps** — Gradual ramp (100→0) + 100 ps unrestrained
 
-Solvation: dodecahedral box with TIP3P water. Ionic conditions are configurable via `OpenMMConfig` fields or the buffer presets (`saliva`, `physiological`, `gastric`, `intestinal`) — defaults are saliva-like (140 mM NaCl + 1.4 mM CaCl2 + 0.5 mM KH2PO4, pH 6.2, 310 K).
+Solvation: dodecahedral box with TIP3P water. Ionic conditions are configurable via `OpenMMConfig` fields or the buffer presets (`physiological`, `saliva`, `gastric`, `intestinal`). Defaults are physiological PBS-like (150 mM NaCl, pH 7.4, 310 K).
 
 ## Development
 

--- a/biolab_runners/boltz2/config.py
+++ b/biolab_runners/boltz2/config.py
@@ -43,8 +43,8 @@ class Boltz2Config:
         no_kernels: Disable cuequivariance custom kernels (use PyTorch fallback).
             Set to True if cuequivariance is not installed.
         use_potentials: Enable steering potentials to reduce steric clashes.
-            Without this, Boltz-2 produces physically impossible structures
-            in 30-60% of predictions.
+            Without this, Boltz-2 frequently produces structures with severe
+            clashes. See the Boltz-2 docs for the underlying discussion.
         output_format: Output structure format (pdb or cif).
         timeout_seconds: Maximum time per prediction before abort.
         boltz_binary: Name or path of the boltz CLI binary.
@@ -62,7 +62,7 @@ class Boltz2Config:
     boltz_binary: str = "boltz"
 
 
-# Quality gate thresholds (calibrated from OralBiome-AMP pipeline)
+# Quality gate thresholds (literature-standard ranges for ipTM / pLDDT)
 IPTM_PASS = 0.7
 IPTM_CONDITIONAL = 0.5
 PLDDT_PASS = 70.0

--- a/biolab_runners/boltz2/runner.py
+++ b/biolab_runners/boltz2/runner.py
@@ -7,7 +7,7 @@ affinity estimates (unique among structure predictors).
 Key advantages:
 - No job limits, no queue wait
 - Commercially usable (Apache 2.0 license)
-- Lower clash rate with steering potentials (~0% vs 30-60% without)
+- Much lower clash rate when steering potentials are enabled (see `use_potentials`)
 - Binding affinity prediction (Pearson r=0.62)
 - ~4 minutes for 100-500 residue complexes on RTX 4090
 
@@ -21,7 +21,7 @@ Usage::
     result = runner.predict_complex(
         receptor_sequence="MVKLTAEG...",
         peptide_sequence="RWKLFKKIEK",
-        name="GtfB_PEP001",
+        name="demo_complex",
         output_dir=Path("results/predictions"),
     )
 """

--- a/biolab_runners/openmm/config.py
+++ b/biolab_runners/openmm/config.py
@@ -10,14 +10,19 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Default ionic conditions (saliva-like; override with presets below or explicit args)
-DEFAULT_NACL_M = 0.140
-DEFAULT_CACL2_M = 0.0014
-DEFAULT_KH2PO4_M = 0.0005
-DEFAULT_PH = 6.2
+# Default ionic conditions (physiological PBS-like; override with presets or explicit args)
+DEFAULT_NACL_M = 0.150
+DEFAULT_CACL2_M = 0.0
+DEFAULT_KH2PO4_M = 0.0
+DEFAULT_PH = 7.4
+
+# Default early-abort iRMSD threshold (Å). Override per-system via
+# OpenMMConfig.target_irmsd_threshold_a. 3.5 Å is a common mid-range value
+# used in peptide-protein binding stability assessment.
+DEFAULT_IRMSD_THRESHOLD_A = 3.5
 
 # Simulation parameters
-TEMPERATURE_K = 310.0  # Oral cavity temperature (37 C)
+TEMPERATURE_K = 310.0  # Body temperature (37 C)
 PRESSURE_ATM = 1.0
 TIMESTEP_FS = 2.0
 BOX_PADDING_NM = 0.8  # 8 A padding
@@ -75,17 +80,21 @@ class EquilibrationStage:
 class OpenMMConfig:
     """Complete configuration for an OpenMM MD simulation.
 
-    Defaults are saliva-like (140 mM NaCl, pH 6.2) to preserve backward
-    compatibility. For other environments use the preset classmethods
-    (``physiological``, ``gastric``, ``intestinal``, ``saliva``) or override
-    fields directly.
+    Defaults are physiological PBS-like (150 mM NaCl, pH 7.4, 310 K). For
+    other environments use the preset classmethods (``physiological``,
+    ``saliva``, ``gastric``, ``intestinal``) or override fields directly.
 
     Attributes:
         receptor_pdb: Path to receptor PDB file.
         peptide_pdb: Path to peptide PDB file.
         output_dir: Output directory for simulation files.
-        target: Target protein name (e.g. "GtfB").
+        target: Optional free-form tag used to group jobs and appear in
+            result metadata. Not interpreted by the runner.
         peptide_id: Peptide identifier.
+        target_irmsd_threshold_a: Reference iRMSD (Å) for the peptide used
+            by the early-abort logic. Runner aborts at 5 ns if peptide Cα
+            RMSD > 2× this value. Override per-system for tighter/looser
+            gating.
         nacl_mol: NaCl concentration in mol/L.
         cacl2_mol: CaCl2 concentration in mol/L.
         kh2po4_mol: KH2PO4 concentration in mol/L.
@@ -148,6 +157,9 @@ class OpenMMConfig:
     # Protonation pH
     protonation_ph: float = DEFAULT_PH
 
+    # Early-abort reference threshold (Å). See DEFAULT_IRMSD_THRESHOLD_A docstring.
+    target_irmsd_threshold_a: float = DEFAULT_IRMSD_THRESHOLD_A
+
     # Computed fields
     total_steps: int = 0
     save_every_steps: int = 0
@@ -198,6 +210,7 @@ class OpenMMConfig:
             },
             "openmm_platform": self.openmm_platform,
             "protonation_ph": self.protonation_ph,
+            "target_irmsd_threshold_a": self.target_irmsd_threshold_a,
             "equilibration": self.equilibration,
             "solvated_atoms": self.solvated_atoms,
         }
@@ -250,6 +263,9 @@ class OpenMMConfig:
             water_model=ff.get("water", WATER_MODEL),
             ligand_ff=ff.get("ligand", LIGAND_FF),
             protonation_ph=data.get("protonation_ph", DEFAULT_PH),
+            target_irmsd_threshold_a=float(
+                data.get("target_irmsd_threshold_a", DEFAULT_IRMSD_THRESHOLD_A)
+            ),
             solvated_atoms=int(data.get("solvated_atoms", 0)),
         )
 
@@ -257,8 +273,7 @@ class OpenMMConfig:
     def saliva(cls, **overrides: Any) -> OpenMMConfig:
         """Saliva-like buffer: 140 mM NaCl + 1.4 mM CaCl2 + 0.5 mM KH2PO4, pH 6.2, 310 K.
 
-        Literature reference values for unstimulated whole saliva. Matches the
-        OralBiome-AMP pipeline defaults.
+        Literature reference values for unstimulated whole saliva.
         """
         return cls(
             **_preset(

--- a/biolab_runners/openmm/runner.py
+++ b/biolab_runners/openmm/runner.py
@@ -5,9 +5,9 @@ The runner handles system building (PDBFixer + solvation), multi-stage
 equilibration, and production NPT with periodic checkpointing, early abort
 checks, and trajectory/energy output.
 
-Defaults to saliva-like conditions (140 mM NaCl, pH 6.2, 310 K) with
-CHARMM36m/TIP3P force fields on GPU (OpenCL or CUDA). Use the
-``OpenMMConfig.physiological``, ``gastric``, ``intestinal``, or ``saliva``
+Defaults to physiological PBS-like conditions (150 mM NaCl, pH 7.4, 310 K)
+with CHARMM36m/TIP3P force fields on GPU (OpenCL or CUDA). Use the
+``OpenMMConfig.physiological``, ``saliva``, ``gastric``, or ``intestinal``
 preset classmethods to target other buffer environments.
 
 Requires: openmm>=8.5.0, pdbfixer>=1.9
@@ -19,7 +19,7 @@ Usage::
     config = OpenMMConfig(
         receptor_pdb="receptor.pdb",
         peptide_pdb="peptide.pdb",
-        output_dir="results/md/GtfB/PEP001",
+        output_dir="results/md",
         production_ns=100.0,
     )
     runner = OpenMMRunner(config)
@@ -62,17 +62,6 @@ class _MdContext:
 
 logger = logging.getLogger(__name__)
 
-# Per-target iRMSD thresholds for early abort (expert-validated)
-TARGET_IRMSD_THRESHOLDS: dict[str, float] = {
-    "FadA": 3.0,
-    "FimA": 3.0,
-    "HmuY": 3.5,
-    "VicK": 3.5,
-    "SpaP": 4.0,
-    "GtfB": 4.0,
-}
-DEFAULT_IRMSD_THRESHOLD = 3.5
-
 # Sub-chunk size for production loop (~5 min wall-clock on RTX 3090)
 SUB_CHUNK_STEPS = 150_000
 
@@ -87,7 +76,7 @@ class OpenMMRunner:
     The runner supports:
     - Resuming from checkpoints (idempotent re-runs)
     - Dry-run mode (validates config without GPU)
-    - Per-target early abort thresholds at 5 ns and 10 ns
+    - Early abort at 5 ns / 10 ns using a per-config iRMSD threshold
     - SIGTERM handling for clean shutdown on preemption
     - Periodic checkpointing to state.xml
 
@@ -158,7 +147,7 @@ class OpenMMRunner:
 
         ref_pep_ca, ref_pep_ca_idx, ref_rec_ca_idx = self._compute_reference_ca(ctx)
 
-        irmsd_thresh = TARGET_IRMSD_THRESHOLDS.get(config.target, DEFAULT_IRMSD_THRESHOLD)
+        irmsd_thresh = config.target_irmsd_threshold_a
         abort_thresh = irmsd_thresh * 2.0
         abort_step_5ns = int(5_000_000 / config.timestep_fs)
         abort_step_10ns = int(10_000_000 / config.timestep_fs)

--- a/tests/test_openmm_runner.py
+++ b/tests/test_openmm_runner.py
@@ -8,15 +8,12 @@ from unittest.mock import patch
 
 import pytest
 from biolab_runners.openmm.config import (
+    DEFAULT_IRMSD_THRESHOLD_A,
     EquilibrationStage,
     OpenMMConfig,
     SimulationResult,
 )
-from biolab_runners.openmm.runner import (
-    DEFAULT_IRMSD_THRESHOLD,
-    TARGET_IRMSD_THRESHOLDS,
-    OpenMMRunner,
-)
+from biolab_runners.openmm.runner import OpenMMRunner
 from biolab_runners.openmm.utils import (
     load_checkpoint_step,
     verify_production_outputs,
@@ -33,12 +30,13 @@ class TestOpenMMConfig:
     def test_defaults(self) -> None:
         config = OpenMMConfig()
         assert config.temperature_k == 310.0
-        assert config.nacl_mol == 0.140
+        assert config.nacl_mol == 0.150
         assert config.protein_ff == "charmm36m"
         assert config.water_model == "tip3p"
         assert config.box_shape == "dodecahedron"
-        assert config.protonation_ph == 6.2
+        assert config.protonation_ph == 7.4
         assert config.production_ns == 100.0
+        assert config.target_irmsd_threshold_a == 3.5
 
     def test_step_computation(self) -> None:
         config = OpenMMConfig(production_ns=100.0, timestep_fs=2.0)
@@ -55,13 +53,13 @@ class TestOpenMMConfig:
             receptor_pdb="rec.pdb",
             peptide_pdb="pep.pdb",
             output_dir="/tmp/out",
-            target="GtfB",
+            target="demo",
             peptide_id="PEP001",
         )
         d = config.to_dict()
         assert d["receptor_pdb"] == "rec.pdb"
-        assert d["target"] == "GtfB"
-        assert d["ionic_conditions"]["NaCl_M"] == 0.140
+        assert d["target"] == "demo"
+        assert d["ionic_conditions"]["NaCl_M"] == 0.150
         assert d["simulation"]["temperature_K"] == 310.0
         assert d["force_fields"]["protein"] == "charmm36m"
 
@@ -70,16 +68,16 @@ class TestOpenMMConfig:
             receptor_pdb="rec.pdb",
             peptide_pdb="pep.pdb",
             output_dir=str(tmp_path),
-            target="FadA",
+            target="demo",
             production_ns=50.0,
         )
         path = config.save()
         assert path.exists()
 
         loaded = OpenMMConfig.from_json(path)
-        assert loaded.target == "FadA"
+        assert loaded.target == "demo"
         assert loaded.production_ns == 50.0
-        assert loaded.nacl_mol == 0.140
+        assert loaded.nacl_mol == 0.150
         assert loaded.protein_ff == "charmm36m"
 
     def test_equilibration_stages_default(self) -> None:
@@ -159,7 +157,7 @@ class TestSimulationResult:
     """Tests for SimulationResult dataclass."""
 
     def test_to_dict(self) -> None:
-        config = OpenMMConfig(target="GtfB", peptide_id="PEP001")
+        config = OpenMMConfig(target="demo", peptide_id="PEP001")
         result = SimulationResult(
             config=config,
             trajectory_path="/tmp/traj.dcd",
@@ -169,7 +167,7 @@ class TestSimulationResult:
             num_atoms=50000,
         )
         d = result.to_dict()
-        assert d["target"] == "GtfB"
+        assert d["target"] == "demo"
         assert d["total_ns"] == 100.0
         assert d["ns_per_day"] == 240.0
 
@@ -256,7 +254,7 @@ class TestOpenMMRunner:
             receptor_pdb=str(tmp_path / "rec.pdb"),
             peptide_pdb=str(tmp_path / "pep.pdb"),
             output_dir=str(tmp_path / "output"),
-            target="GtfB",
+            target="demo",
             peptide_id="PEP001",
             production_ns=100.0,
         )
@@ -302,21 +300,40 @@ class TestOpenMMRunner:
 
 
 # ---------------------------------------------------------------------------
-# Target threshold tests
+# iRMSD threshold tests
 # ---------------------------------------------------------------------------
 
 
-class TestTargetThresholds:
-    """Tests for per-target iRMSD thresholds."""
+class TestIrmsdThreshold:
+    """Tests for the per-config iRMSD early-abort threshold."""
 
-    def test_known_targets(self) -> None:
-        assert TARGET_IRMSD_THRESHOLDS["FadA"] == 3.0
-        assert TARGET_IRMSD_THRESHOLDS["GtfB"] == 4.0
-        assert TARGET_IRMSD_THRESHOLDS["VicK"] == 3.5
+    def test_default_value(self) -> None:
+        assert DEFAULT_IRMSD_THRESHOLD_A == 3.5
 
-    def test_default_threshold(self) -> None:
-        assert DEFAULT_IRMSD_THRESHOLD == 3.5
+    def test_default_applied_to_config(self) -> None:
+        config = OpenMMConfig(
+            receptor_pdb="r.pdb",
+            peptide_pdb="p.pdb",
+            output_dir="out",
+        )
+        assert config.target_irmsd_threshold_a == DEFAULT_IRMSD_THRESHOLD_A
 
-    def test_unknown_target_uses_default(self) -> None:
-        thresh = TARGET_IRMSD_THRESHOLDS.get("UnknownTarget", DEFAULT_IRMSD_THRESHOLD)
-        assert thresh == 3.5
+    def test_override_via_config(self) -> None:
+        config = OpenMMConfig(
+            receptor_pdb="r.pdb",
+            peptide_pdb="p.pdb",
+            output_dir="out",
+            target_irmsd_threshold_a=4.0,
+        )
+        assert config.target_irmsd_threshold_a == 4.0
+
+    def test_roundtrip_through_json(self, tmp_path: Path) -> None:
+        config = OpenMMConfig(
+            receptor_pdb="r.pdb",
+            peptide_pdb="p.pdb",
+            output_dir=str(tmp_path),
+            target_irmsd_threshold_a=2.75,
+        )
+        path = config.save()
+        loaded = OpenMMConfig.from_json(path)
+        assert loaded.target_irmsd_threshold_a == 2.75


### PR DESCRIPTION
## Summary

Makes `biolab-runners` domain-neutral so it reads as a generic peptide-protein MD + structure-prediction library rather than the working notes of an oral-AMP pipeline. Same capabilities, same API surface + one new config field, fewer leaks.

## Motivation

The original extraction carried a handful of oral-microbiome specifics that made the public library read as project documentation:

- **Per-target iRMSD dict** hardcoded in `openmm/runner.py` with six oral-pathogen target names (GtfB, SpaP, VicK, HmuY, FadA, FimA) and expert-calibrated thresholds — the exact set of targets in active pursuit, plus the tuning numbers derived from dozens of 100 ns runs.
- **Saliva-like defaults** in `OpenMMConfig` (140 mM NaCl + 1.4 mM CaCl₂ + 0.5 mM KH₂PO₄, pH 6.2, 310 K) hardcoded as the module default, with a docstring explicitly attributing them to OralBiome-AMP.
- **Per-target threshold table** reproduced in `README.md`.
- **Example identifiers** (`GtfB_PEP001`, `results/md/GtfB/PEP001`) in README + runner docstrings + tests.
- **Quantitative "30-60% of predictions carry severe clashes" claim** from internal observations, surfacing in six places.
- **`# Quality gate thresholds (calibrated from OralBiome-AMP pipeline)` comment** in `boltz2/config.py`.

None of this was technically secret — nothing here is patent-adjacent. But together it told a reader "this is the oral-AMP team's library" instead of "this is a generic MD runner." For a library we want UTI-project, bioml-commons, and outside collaborators to consume freely, that framing is worth removing.

## What changed

### Breaking-ish (no existing consumers on main yet)

- `OpenMMConfig` field defaults flip from saliva-like to physiological PBS (150 mM NaCl, pH 7.4, 310 K). The `saliva()` preset classmethod is unchanged — callers who need saliva conditions now opt in explicitly via `OpenMMConfig.saliva(...)` instead of getting them for free from `OpenMMConfig()`.
- `TARGET_IRMSD_THRESHOLDS` dict removed from `openmm/runner.py`. Early-abort threshold now lives on `OpenMMConfig.target_irmsd_threshold_a` (default 3.5 Å). Callers needing per-system tuning set it on the config rather than relying on a name lookup. This actually makes the runner more general: non-oral targets no longer silently get the 3.5 Å fallback with no indication that the value is a placeholder.
- `DEFAULT_IRMSD_THRESHOLD_A` constant now lives in `openmm/config.py` (previously `openmm/runner.py` as `DEFAULT_IRMSD_THRESHOLD`).

### Non-breaking

- Soften the "30-60% of predictions are physically impossible" claim across README, AGENTS.md, AGENT_LEARNINGS.md, `.claude/rules/steering-potentials.md`, `boltz2/config.py`, and `boltz2/runner.py`. All now say "a substantial fraction" and point at the Boltz-2 paper / `use_potentials` docs.
- README: drop the per-target iRMSD threshold table. Replace with a prose paragraph explaining that `target_irmsd_threshold_a` is per-system and defaults to 3.5 Å.
- README + docstrings + tests: swap `GtfB_PEP001`, `target="GtfB"`, `target="FadA"`, `results/md/GtfB/PEP001` → `demo_complex`, `target="demo"`, `results/md/demo`. `PEP001` stays because it reads as a generic "peptide 001" identifier.
- `boltz2/config.py`: remove "calibrated from OralBiome-AMP pipeline" attribution on the quality-gate threshold block. The numerical values (ipTM ≥ 0.7 PASS, ≥ 0.5 CONDITIONAL; pLDDT ≥ 70 / ≥ 50) are literature-standard cutoffs and stay unchanged.
- AGENTS.md: update the "Buffer environment" line to reflect the new PBS default.

### Intentionally preserved

- The `OralBiome-AMP` extraction-origin attribution in AGENTS.md and README (`extracted from the OralBiome-AMP pipeline`). That's open-source lineage, not a leak, and attribution is appropriate.
- All four buffer presets (`physiological`, `saliva`, `gastric`, `intestinal`). Saliva is now a preset among equals rather than the default.
- The equilibration protocol numbers (NVT 100 ps @ k=1000 → NPT 100 ps @ k=100 → NPT 200 ps ramp). These are generic peptide-protein equilibration practice, not project-specific.
- Force field defaults (CHARMM36m / TIP3P / dodecahedron). Standard choices.

## Test plan

- [x] `make validate` passes (ruff + pyright + complexipy + pytest)
- [x] 62/62 pytest pass
- [x] Grep for `GtfB|SpaP|VicK|HmuY|FadA|FimA|GtfG|SspB|cariogenic|periodont|nisin|APD3|DRAMP|30-60|~36%|TARGET_IRMSD` across the tree returns **no matches**
- [x] New `TestIrmsdThreshold` class exercises: default value, default applied to a fresh `OpenMMConfig`, override via config, and JSON roundtrip through `save()` / `from_json()`
- [x] `uv.lock` not touched (upstream doesn't track it)

## What this doesn't do

- Doesn't touch vastai-gpu-runner (separate concern).
- Doesn't change any production behavior for tuned systems — OralBiome-AMP, when it eventually adopts biolab-runners as a dep, will pass `target_irmsd_threshold_a=3.0/3.5/4.0` explicitly per target in its own code.
- Doesn't remove the AGENT_LEARNINGS.md entries — they stay as genuinely useful incident writeups, just with the quantitative claim softened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)