### PR TITLE
feat: add SBOM and llms.txt workflows

### DIFF
--- a/.github/templates/llms.txt.tpl
+++ b/.github/templates/llms.txt.tpl
@@ -1,0 +1,26 @@
+# biolab-runners
+
+> Standalone, modular Python runners for Boltz-2 structure prediction and OpenMM molecular dynamics simulations.
+
+## Documentation
+
+- [README](${BLOB}/README.md): Project overview, architecture, usage, and dependency notes
+- [CLAUDE.md](${BLOB}/CLAUDE.md): Agent instructions, architecture details, and common gotchas
+
+## Source — biolab_runners
+
+### Core
+
+- [biolab_runners/__init__.py](${BLOB}/biolab_runners/__init__.py): Package root and version
+
+### Boltz-2 structure prediction (boltz2/)
+
+- [boltz2/runner.py](${BLOB}/biolab_runners/boltz2/runner.py): Boltz2Runner class — invokes boltz predict CLI, parses confidence scores, applies quality gate
+- [boltz2/config.py](${BLOB}/biolab_runners/boltz2/config.py): Boltz2Config, ConfidenceScores, PredictionResult, QualityGate dataclasses
+- [boltz2/utils.py](${BLOB}/biolab_runners/boltz2/utils.py): YAML input writer, output parser, boltz CLI availability check
+
+### OpenMM molecular dynamics (openmm/)
+
+- [openmm/runner.py](${BLOB}/biolab_runners/openmm/runner.py): OpenMMRunner class — system building, multi-stage equilibration, production NPT with checkpointing
+- [openmm/config.py](${BLOB}/biolab_runners/openmm/config.py): OpenMMConfig, SimulationResult, EquilibrationStage dataclasses
+- [openmm/utils.py](${BLOB}/biolab_runners/openmm/utils.py): Output verification, checkpoint loading, OpenMM availability check

--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -1,0 +1,22 @@
+name: Generate SBOM
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: qte77/gha-sbom-action@v0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/write-llms-txt.yaml
+++ b/.github/workflows/write-llms-txt.yaml
@@ -1,0 +1,52 @@
+name: Write llms.txt
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/templates/llms.txt.tpl"
+      - "biolab_runners/**"
+      - "README.md"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  write-llms-txt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set BLOB URL
+        id: vars
+        run: echo "BLOB=https://github.com/${{ github.repository }}/blob/${{ github.sha }}" >> "$GITHUB_ENV"
+
+      - name: Render llms.txt from template
+        run: envsubst < .github/templates/llms.txt.tpl > llms.txt
+
+      - name: Check for changes
+        id: detect
+        run: |
+          git add llms.txt
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create PR
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          BRANCH="auto/llms-txt-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git commit -m "docs: update llms.txt"
+          git push -u origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "docs: update llms.txt" \
+            --body "Auto-generated from \`.github/templates/llms.txt.tpl\`."


### PR DESCRIPTION
## Summary

- Add `generate-sbom.yaml` workflow: runs weekly and on push to main, generates SPDX SBOMs via `qte77/gha-sbom-action`
- Add `write-llms-txt.yaml` workflow: renders `llms.txt` from template on source/doc changes, auto-creates PR
- Add `.github/templates/llms.txt.tpl`: llms.txt template with linked documentation and all source modules

## Test plan

- [ ] Verify `generate-sbom.yaml` runs successfully via workflow_dispatch
- [ ] Verify `write-llms-txt.yaml` renders llms.txt correctly via workflow_dispatch
- [ ] Confirm generated llms.txt links resolve to valid blob URLs
- [ ] Confirm SBOM PR is created with valid SPDX JSON output

Generated with Claude <noreply@anthropic.com>