### PR TITLE
feat(openmm): extra_forcefields for non-canonical residue XML

### DIFF
--- a/biolab_runners/openmm/config.py
+++ b/biolab_runners/openmm/config.py
@@ -106,6 +106,13 @@ class OpenMMConfig:
         protein_ff: Protein force field name.
         water_model: Water model name.
         ligand_ff: Ligand force field name.
+        extra_forcefields: Additional OpenMM force-field XML files to load
+            alongside ``protein_ff`` and ``water_model``. Each entry is the
+            path (str) to an XML file accepted by ``openmm.app.ForceField``.
+            Use for non-canonical residues, small molecules, or user-supplied
+            parameter overrides. Entries are appended in order; later files
+            take precedence for overlapping atom types. Defaults to the empty
+            list.
         openmm_platform: OpenMM platform ("OpenCL", "CUDA", "CPU").
         equilibration: List of equilibration stage dicts.
         production_ns: Production simulation length in nanoseconds.
@@ -140,6 +147,7 @@ class OpenMMConfig:
     protein_ff: str = PROTEIN_FF
     water_model: str = WATER_MODEL
     ligand_ff: str = LIGAND_FF
+    extra_forcefields: list[str] = field(default_factory=list)
 
     # GPU platform
     openmm_platform: str = OPENMM_PLATFORM
@@ -207,6 +215,7 @@ class OpenMMConfig:
                 "protein": self.protein_ff,
                 "water": self.water_model,
                 "ligand": self.ligand_ff,
+                "extra": list(self.extra_forcefields),
             },
             "openmm_platform": self.openmm_platform,
             "protonation_ph": self.protonation_ph,
@@ -262,6 +271,7 @@ class OpenMMConfig:
             protein_ff=ff.get("protein", PROTEIN_FF),
             water_model=ff.get("water", WATER_MODEL),
             ligand_ff=ff.get("ligand", LIGAND_FF),
+            extra_forcefields=list(ff.get("extra", []) or []),
             protonation_ph=data.get("protonation_ph", DEFAULT_PH),
             target_irmsd_threshold_a=float(
                 data.get("target_irmsd_threshold_a", DEFAULT_IRMSD_THRESHOLD_A)

--- a/biolab_runners/openmm/runner.py
+++ b/biolab_runners/openmm/runner.py
@@ -346,11 +346,17 @@ class OpenMMRunner:
 
     @staticmethod
     def _build_forcefield(config: OpenMMConfig, app: object) -> object:
-        """Construct the OpenMM ForceField for the configured protein FF + water."""
+        """Construct the OpenMM ForceField for the configured protein FF + water.
+
+        ``config.extra_forcefields`` is appended after the protein and water
+        XMLs so later entries take precedence for overlapping atom types.
+        """
         ff_name = config.protein_ff
         if "charmm" in ff_name.lower():
-            return app.ForceField("charmm36.xml", "charmm36/water.xml")  # type: ignore[union-attr]
-        return app.ForceField(f"{ff_name}.xml", f"{config.water_model}.xml")  # type: ignore[union-attr]
+            base = ["charmm36.xml", "charmm36/water.xml"]
+        else:
+            base = [f"{ff_name}.xml", f"{config.water_model}.xml"]
+        return app.ForceField(*base, *config.extra_forcefields)  # type: ignore[union-attr]
 
     def _build_or_load_modeller(
         self,

--- a/tests/test_openmm_runner.py
+++ b/tests/test_openmm_runner.py
@@ -87,6 +87,42 @@ class TestOpenMMConfig:
         assert config.equilibration[0]["restraint_k"] == 1000.0
         assert config.equilibration[2]["restraint_k"] == 0.0
 
+    def test_extra_forcefields_default_empty(self) -> None:
+        config = OpenMMConfig()
+        assert config.extra_forcefields == []
+
+    def test_extra_forcefields_not_shared_between_instances(self) -> None:
+        """Default list must be per-instance (no mutable default aliasing)."""
+        a = OpenMMConfig()
+        b = OpenMMConfig()
+        a.extra_forcefields.append("/tmp/a.xml")
+        assert b.extra_forcefields == []
+
+    def test_extra_forcefields_roundtrip(self, tmp_path: Path) -> None:
+        extras = [str(tmp_path / "custom_a.xml"), str(tmp_path / "custom_b.xml")]
+        config = OpenMMConfig(
+            receptor_pdb="rec.pdb",
+            output_dir=str(tmp_path),
+            extra_forcefields=extras,
+        )
+        d = config.to_dict()
+        assert d["force_fields"]["extra"] == extras
+
+        path = config.save()
+        loaded = OpenMMConfig.from_json(path)
+        assert loaded.extra_forcefields == extras
+
+    def test_extra_forcefields_absent_in_legacy_json(self, tmp_path: Path) -> None:
+        """JSONs written before this field existed must still load cleanly."""
+        legacy = {
+            "receptor_pdb": "rec.pdb",
+            "force_fields": {"protein": "amber14/protein.ff14SB", "water": "tip3p"},
+        }
+        path = tmp_path / "legacy.json"
+        path.write_text(json.dumps(legacy))
+        loaded = OpenMMConfig.from_json(path)
+        assert loaded.extra_forcefields == []
+
     def test_preset_saliva(self) -> None:
         config = OpenMMConfig.saliva()
         assert config.nacl_mol == 0.140
@@ -124,6 +160,51 @@ class TestOpenMMConfig:
         assert config.production_ns == 25.0
         assert config.protonation_ph == 7.0
         assert config.nacl_mol == 0.150  # preset value preserved
+
+
+class _RecordingForceField:
+    """Fake ``app.ForceField`` that records the XML paths it was constructed with."""
+
+    def __init__(self, *paths: str) -> None:
+        self.paths: tuple[str, ...] = paths
+
+
+class _FakeApp:
+    """Minimal stand-in for ``openmm.app`` used by ``_build_forcefield``."""
+
+    ForceField = _RecordingForceField
+
+
+class TestBuildForcefield:
+    """Tests for ``OpenMMRunner._build_forcefield`` extra_forcefields pass-through."""
+
+    def test_amber_no_extras(self) -> None:
+        config = OpenMMConfig(protein_ff="amber14/protein.ff14SB", water_model="tip3p")
+        ff = OpenMMRunner._build_forcefield(config, _FakeApp())
+        assert ff.paths == ("amber14/protein.ff14SB.xml", "tip3p.xml")
+
+    def test_amber_with_extras(self, tmp_path: Path) -> None:
+        extra = str(tmp_path / "custom.xml")
+        config = OpenMMConfig(
+            protein_ff="amber14/protein.ff14SB",
+            water_model="tip3p",
+            extra_forcefields=[extra],
+        )
+        ff = OpenMMRunner._build_forcefield(config, _FakeApp())
+        assert ff.paths == ("amber14/protein.ff14SB.xml", "tip3p.xml", extra)
+
+    def test_charmm_with_extras(self, tmp_path: Path) -> None:
+        """CHARMM branch must still honour extra_forcefields."""
+        extra = str(tmp_path / "custom.xml")
+        config = OpenMMConfig(protein_ff="charmm36m", extra_forcefields=[extra])
+        ff = OpenMMRunner._build_forcefield(config, _FakeApp())
+        assert ff.paths == ("charmm36.xml", "charmm36/water.xml", extra)
+
+    def test_extras_preserve_order(self, tmp_path: Path) -> None:
+        extras = [str(tmp_path / "a.xml"), str(tmp_path / "b.xml")]
+        config = OpenMMConfig(protein_ff="amber14/protein.ff14SB", extra_forcefields=extras)
+        ff = OpenMMRunner._build_forcefield(config, _FakeApp())
+        assert ff.paths[-2:] == tuple(extras)
 
 
 class TestEquilibrationStage:


### PR DESCRIPTION
Same tree as #15; recreated with a signed commit so it satisfies the `required_signatures` rule on `main`.

## Summary

- Add `OpenMMConfig.extra_forcefields: list[str]` so callers can pass additional OpenMM force-field XML files (non-canonical residues, small-molecule parameter sets, user overrides) alongside the protein and water models.
- `_build_forcefield` threads the extras into `app.ForceField(*base, *config.extra_forcefields)`. Extras are appended after the protein+water XMLs so later entries take precedence for overlapping atom types — the standard OpenMM ForceField merge semantics.
- Roundtrips through `to_dict` / `from_json`; legacy JSON files without the `extra` key load as the empty list.

## Motivation

Downstream pipelines (e.g. OralBiome-AMP gen-2) are running MD on peptides that contain non-canonical residues — e.g. α-aminoisobutyric acid (Aib, CCD code `AIB`) — for which ff14SB/charmm36m ship no residue template. Today those pipelines have to monkey-patch `_build_forcefield`; this PR gives them a first-class config field instead. The change is intentionally generic: the runner has no opinion about what's in the extra XML.

## Test plan

- [x] `make validate` — ruff format + ruff check + pyright + complexipy + pytest all green (70/70, +8 new tests)
- [x] `TestOpenMMConfig::test_extra_forcefields_default_empty` — default is empty list
- [x] `TestOpenMMConfig::test_extra_forcefields_not_shared_between_instances` — guards against mutable-default aliasing
- [x] `TestOpenMMConfig::test_extra_forcefields_roundtrip` — save/load preserves the list and its order
- [x] `TestOpenMMConfig::test_extra_forcefields_absent_in_legacy_json` — pre-existing JSON still loads
- [x] `TestBuildForcefield` — 4 cases exercising the amber/charmm branches with and without extras, asserting XML path order

## Notes

- Pure config-plumbing PR; no behavioural change for callers that don't set `extra_forcefields`.
- Pre-existing `reportAttributeAccessIssue` pyright warning on `runner.py:291` is unrelated.
- Supersedes #15 (closed unmerged — unsigned commit blocked by ruleset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)