### PR TITLE
feat(boltz2): modifications for non-canonical residues in YAML

### DIFF
--- a/biolab_runners/boltz2/utils.py
+++ b/biolab_runners/boltz2/utils.py
@@ -43,11 +43,13 @@ def write_boltz_yaml(
     msa_paths: dict[str, str] | None = None,
     pocket_contacts: list[tuple[str, int]] | None = None,
     binder_chain: str = "B",
+    modifications: dict[str, list[dict[str, object]]] | None = None,
 ) -> Path:
     """Write a Boltz-2 v2 YAML input file.
 
     Boltz-2 v2 uses YAML as the primary input format, supporting multi-chain
-    complexes, pre-computed MSAs, and pocket constraints.
+    complexes, pre-computed MSAs, pocket constraints, and non-canonical
+    residue modifications via the PDB CCD dictionary.
 
     Args:
         sequences: Dict mapping chain_id to amino acid sequence.
@@ -57,11 +59,20 @@ def write_boltz_yaml(
         pocket_contacts: Optional list of (chain_id, residue_number) tuples
             specifying receptor residues the binder must contact.
         binder_chain: Chain ID of the binder/peptide (default "B").
+        modifications: Optional dict mapping chain_id to a list of residue
+            modifications. Each modification is a dict with keys
+            ``position`` (1-indexed residue number) and ``ccd`` (PDB CCD
+            three/four-letter code, e.g. ``"AIB"`` for α-aminoisobutyric
+            acid). Boltz-2 replaces the sequence token at ``position-1``
+            with the CCD residue during parsing, yielding the correct
+            non-canonical heavy-atom set in the output structure. See
+            ``boltz.data.parse.schema`` for the upstream contract.
 
     Returns:
         Path to the written YAML file.
     """
     msa_paths = msa_paths or {}
+    modifications = modifications or {}
     output_path.parent.mkdir(parents=True, exist_ok=True)
     lines = ["version: 1", "sequences:"]
     for chain_id, seq in sequences.items():
@@ -70,6 +81,12 @@ def write_boltz_yaml(
         lines.append(f"      sequence: {seq}")
         if chain_id in msa_paths:
             lines.append(f"      msa: {msa_paths[chain_id]}")
+        chain_mods = modifications.get(chain_id)
+        if chain_mods:
+            lines.append("      modifications:")
+            for mod in chain_mods:
+                lines.append(f"        - position: {mod['position']}")
+                lines.append(f"          ccd: {mod['ccd']}")
 
     if pocket_contacts:
         lines.append("constraints:")

--- a/tests/test_boltz2_runner.py
+++ b/tests/test_boltz2_runner.py
@@ -187,6 +187,68 @@ class TestWriteBoltzYaml:
         assert "[A, 123]" in content
         assert "[A, 456]" in content
 
+    def test_yaml_with_modifications(self, tmp_path: Path) -> None:
+        """Non-canonical residue modifications land under the right chain."""
+        yaml_path = tmp_path / "input.yaml"
+        write_boltz_yaml(
+            {"A": "MVKL", "B": "BKALBKKWBAWF"},
+            yaml_path,
+            modifications={
+                "B": [
+                    {"position": 1, "ccd": "AIB"},
+                    {"position": 5, "ccd": "AIB"},
+                    {"position": 9, "ccd": "AIB"},
+                ]
+            },
+        )
+        content = yaml_path.read_text()
+        assert "modifications:" in content
+        assert "- position: 1" in content
+        assert "ccd: AIB" in content
+        # 3 positions + 3 ccd entries
+        assert content.count("position:") == 3
+        assert content.count("ccd:") == 3
+
+        # Modifications block must nest under chain B only
+        b_block_start = content.index("id: B")
+        b_block = content[b_block_start:]
+        a_block = content[:b_block_start]
+        assert "modifications:" in b_block
+        assert "modifications:" not in a_block
+
+    def test_yaml_without_modifications_has_no_block(self, tmp_path: Path) -> None:
+        """Omitting modifications must not emit an empty 'modifications:' key."""
+        yaml_path = tmp_path / "input.yaml"
+        write_boltz_yaml({"A": "MVKL", "B": "RWKL"}, yaml_path)
+        assert "modifications:" not in yaml_path.read_text()
+
+    def test_yaml_modifications_empty_chain_list_skipped(self, tmp_path: Path) -> None:
+        """A chain with an empty mod list must not produce a header line."""
+        yaml_path = tmp_path / "input.yaml"
+        write_boltz_yaml(
+            {"A": "MVKL", "B": "RWKL"},
+            yaml_path,
+            modifications={"B": []},
+        )
+        assert "modifications:" not in yaml_path.read_text()
+
+    def test_yaml_modifications_coexist_with_msa_and_contacts(self, tmp_path: Path) -> None:
+        """All three optional blocks render together without interfering."""
+        yaml_path = tmp_path / "input.yaml"
+        write_boltz_yaml(
+            {"A": "MVKL", "B": "BKAL"},
+            yaml_path,
+            msa_paths={"A": "/data/msa.csv", "B": "empty"},
+            pocket_contacts=[("A", 42)],
+            modifications={"B": [{"position": 1, "ccd": "AIB"}]},
+        )
+        content = yaml_path.read_text()
+        assert "msa: /data/msa.csv" in content
+        assert "msa: empty" in content
+        assert "modifications:" in content
+        assert "constraints:" in content
+        assert "[A, 42]" in content
+
 
 # ---------------------------------------------------------------------------
 # Output validation tests


### PR DESCRIPTION
## Summary

- Add ``modifications`` parameter to ``write_boltz_yaml`` so callers can declare non-canonical residues via the PDB CCD dictionary.
- Each entry is ``{"position": N, "ccd": "XXX"}``, keyed by chain id — matches the upstream schema in ``boltz.data.parse.schema``.
- Zero change for callers that don't pass modifications: the YAML block only renders when a chain has a non-empty list.

## Motivation

Peptides containing α-aminoisobutyric acid (Aib, 1-letter code ``B``) are currently serialised with the raw ``B`` token in the sequence. Boltz-2 treats this as an unknown polymer code and emits ``UNK`` 5-heavy-atom residues (N, CA, C, O, single CB) in the predicted structure.

The correct α,α-dimethyl 6-atom set (N, CA, CB1, CB2, C, O) — required by downstream MD force-field parameterisation — is recoverable only via the ``modifications`` block, which Boltz's parser uses to swap ``token[position-1]`` for the specified CCD entry during polymer parsing.

## Test plan

- [x] ``make validate`` — ruff + pyright + complexipy + pytest green (74/74, +4 new)
- [x] ``test_yaml_with_modifications`` — 3 AIB mods on chain B, asserts nesting under the right chain
- [x] ``test_yaml_without_modifications_has_no_block`` — no empty header when unused
- [x] ``test_yaml_modifications_empty_chain_list_skipped`` — empty list on a chain is a no-op
- [x] ``test_yaml_modifications_coexist_with_msa_and_contacts`` — all three optional blocks compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)