### PR TITLE
feat(boltz2): thread modifications through Boltz2Runner.predict_complex

### DIFF
--- a/biolab_runners/boltz2/runner.py
+++ b/biolab_runners/boltz2/runner.py
@@ -314,6 +314,7 @@ class Boltz2Runner:
         pocket_contacts: list[tuple[str, int]] | None = None,
         seed: int | None = None,
         dry_run: bool = False,
+        modifications: dict[str, list[dict[str, object]]] | None = None,
     ) -> PredictionResult:
         """Predict a peptide-protein complex structure with Boltz-2.
 
@@ -329,6 +330,12 @@ class Boltz2Runner:
                 for spatially constrained prediction.
             seed: Random seed for reproducible predictions.
             dry_run: Validate inputs and log the command without executing.
+            modifications: Optional dict mapping chain_id to a list of
+                ``{"position": N, "ccd": "XXX"}`` entries. Forwarded to
+                ``write_boltz_yaml`` so non-canonical residues (e.g. Aib
+                as CCD ``AIB``) get the correct heavy-atom set in the
+                predicted structure. See ``write_boltz_yaml`` for the
+                schema.
 
         Returns:
             PredictionResult with quality gate applied.
@@ -385,6 +392,7 @@ class Boltz2Runner:
             yaml_path,
             msa_paths=msa_paths,
             pocket_contacts=pocket_contacts,
+            modifications=modifications,
         )
 
         cmd = self._build_command(

--- a/tests/test_boltz2_runner.py
+++ b/tests/test_boltz2_runner.py
@@ -417,6 +417,33 @@ class TestBoltz2Runner:
         assert result.quality_gate == QualityGate.FAIL
         assert "CUDA OOM" in result.error
 
+    def test_modifications_flow_into_yaml(self, tmp_path: Path) -> None:
+        """modifications passed to predict_complex must land in the emitted YAML."""
+        with patch("biolab_runners.boltz2.runner.boltz_available", return_value=True):
+            with patch("subprocess.run") as mock_run:
+                # Non-zero exit so the runner stops after YAML + command — we only
+                # care that the YAML got written, not that the subprocess succeeds.
+                mock_run.return_value = MagicMock(returncode=1, stderr="no GPU")
+                runner = Boltz2Runner()
+                runner.predict_complex(
+                    receptor_sequence="MVKLTAEG",
+                    peptide_sequence="BKALBKKWBAWF",
+                    name="aib_mod_test",
+                    output_dir=tmp_path,
+                    modifications={
+                        "B": [
+                            {"position": 1, "ccd": "AIB"},
+                            {"position": 5, "ccd": "AIB"},
+                            {"position": 9, "ccd": "AIB"},
+                        ]
+                    },
+                )
+        yaml_path = tmp_path / "aib_mod_test" / "boltz2" / "input.yaml"
+        content = yaml_path.read_text()
+        assert "modifications:" in content
+        assert "ccd: AIB" in content
+        assert content.count("position:") == 3
+
 
 # ---------------------------------------------------------------------------
 # Config / result serialization tests


### PR DESCRIPTION
Completes the non-canonical-residue path started in #17.

## Summary

- Add ``modifications`` keyword to ``Boltz2Runner.predict_complex``.
- Forward unchanged into ``write_boltz_yaml``.

## Motivation

Without this, callers wanting Aib (or any CCD-backed ncAA) would have to bypass ``Boltz2Runner`` and write the YAML by hand. #17 introduced the YAML-level support; this PR makes it usable from the runner entry point that downstream pipelines already call (e.g. OralBiome-AMP's ``Boltz2Predictor``).

## Test plan

- [x] ``make validate`` — ruff + pyright + complexipy + pytest green (75/75, +1 new)
- [x] ``test_modifications_flow_into_yaml`` — constructs a runner, calls ``predict_complex`` with 3 AIB mods on chain B, asserts the rendered YAML contains ``modifications:`` + ``ccd: AIB`` + 3 ``position:`` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)