### PR TITLE
fix(boltz2): force=True adds --override so re-prediction actually runs (#19)

### DIFF
--- a/biolab_runners/boltz2/runner.py
+++ b/biolab_runners/boltz2/runner.py
@@ -358,6 +358,7 @@ class Boltz2Runner:
                 boltz_output=output_dir / name / "boltz2" / "output",
                 num_seeds=seeds,
                 seed=seed,
+                force=force,
             )
             logger.info(
                 "[DRY-RUN] Would run: %s (receptor=%d aa, peptide=%d aa)",
@@ -400,6 +401,7 @@ class Boltz2Runner:
             boltz_output=boltz_output,
             num_seeds=seeds,
             seed=seed,
+            force=force,
         )
         logger.info("Running Boltz-2: %s", " ".join(cmd))
 
@@ -424,8 +426,17 @@ class Boltz2Runner:
 
         return apply_quality_gate(result)
 
-    def _build_monomer_command(self, yaml_path: Path, boltz_output: Path) -> list[str]:
-        """Build the boltz predict CLI command for a monomer run."""
+    def _build_monomer_command(
+        self,
+        yaml_path: Path,
+        boltz_output: Path,
+        force: bool = False,
+    ) -> list[str]:
+        """Build the boltz predict CLI command for a monomer run.
+
+        ``force=True`` adds ``--override`` so Boltz re-runs even when
+        ``--out_dir`` already contains predictions. See ``_build_command``.
+        """
         cfg = self.config
         cmd = [
             cfg.boltz_binary,
@@ -446,6 +457,8 @@ class Boltz2Runner:
             cmd.append("--no_kernels")
         if cfg.use_potentials:
             cmd.append("--use_potentials")
+        if force:
+            cmd.append("--override")
         return cmd
 
     def predict_monomer(
@@ -499,7 +512,7 @@ class Boltz2Runner:
             return apply_quality_gate(result)
 
         yaml_path = write_boltz_yaml({"A": sequence}, run_dir / "input.yaml")
-        cmd = self._build_monomer_command(yaml_path, boltz_output)
+        cmd = self._build_monomer_command(yaml_path, boltz_output, force=force)
 
         if not self._run_boltz_subprocess(cmd, result, stderr_limit=300):
             return apply_quality_gate(result)
@@ -515,8 +528,16 @@ class Boltz2Runner:
         boltz_output: Path,
         num_seeds: int,
         seed: int | None,
+        force: bool = False,
     ) -> list[str]:
-        """Build the boltz predict CLI command."""
+        """Build the boltz predict CLI command.
+
+        ``force=True`` adds ``--override`` so the ``boltz predict`` binary
+        re-runs even when ``--out_dir`` already contains predictions.
+        Without it, Boltz silently exits in <5 s when the output dir is
+        populated — defeating ``predict_complex(force=True)`` after the
+        internal cache check is bypassed.
+        """
         cfg = self.config
         cmd = [
             cfg.boltz_binary,
@@ -545,4 +566,6 @@ class Boltz2Runner:
             cmd.append("--use_potentials")
         if seed is not None:
             cmd.extend(["--seed", str(seed)])
+        if force:
+            cmd.append("--override")
         return cmd

--- a/tests/test_boltz2_runner.py
+++ b/tests/test_boltz2_runner.py
@@ -445,6 +445,83 @@ class TestBoltz2Runner:
         assert content.count("position:") == 3
 
 
+class TestForceOverride:
+    """``force=True`` must append ``--override`` to the boltz CLI command.
+
+    Without it the ``boltz predict`` binary silently no-ops when
+    ``--out_dir`` already contains predictions, so re-running a
+    ``predict_complex(force=True)`` after e.g. regenerating input YAML
+    appears to succeed but leaves the stale PDBs on disk.
+    """
+
+    def test_complex_force_false_no_override(self) -> None:
+        runner = Boltz2Runner()
+        cmd = runner._build_command(
+            yaml_path=Path("input.yaml"),
+            boltz_output=Path("output"),
+            num_seeds=1,
+            seed=None,
+            force=False,
+        )
+        assert "--override" not in cmd
+
+    def test_complex_force_true_appends_override(self) -> None:
+        runner = Boltz2Runner()
+        cmd = runner._build_command(
+            yaml_path=Path("input.yaml"),
+            boltz_output=Path("output"),
+            num_seeds=1,
+            seed=None,
+            force=True,
+        )
+        assert cmd.count("--override") == 1
+
+    def test_complex_force_default_is_false(self) -> None:
+        """Omitting the flag preserves backwards-compatible behaviour."""
+        runner = Boltz2Runner()
+        cmd = runner._build_command(
+            yaml_path=Path("input.yaml"),
+            boltz_output=Path("output"),
+            num_seeds=1,
+            seed=None,
+        )
+        assert "--override" not in cmd
+
+    def test_monomer_force_true_appends_override(self) -> None:
+        runner = Boltz2Runner()
+        cmd = runner._build_monomer_command(
+            yaml_path=Path("input.yaml"),
+            boltz_output=Path("output"),
+            force=True,
+        )
+        assert cmd.count("--override") == 1
+
+    def test_monomer_force_false_no_override(self) -> None:
+        runner = Boltz2Runner()
+        cmd = runner._build_monomer_command(
+            yaml_path=Path("input.yaml"),
+            boltz_output=Path("output"),
+            force=False,
+        )
+        assert "--override" not in cmd
+
+    def test_predict_complex_threads_force_through(self, tmp_path: Path) -> None:
+        """End-to-end: ``predict_complex(force=True)`` → command has ``--override``."""
+        with patch("biolab_runners.boltz2.runner.boltz_available", return_value=True):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1, stderr="stop")
+                runner = Boltz2Runner()
+                runner.predict_complex(
+                    receptor_sequence="MVKLTAEG",
+                    peptide_sequence="RWKLFKK",
+                    name="force_e2e",
+                    output_dir=tmp_path,
+                    force=True,
+                )
+                invoked_cmd = mock_run.call_args.args[0]
+        assert "--override" in invoked_cmd
+
+
 # ---------------------------------------------------------------------------
 # Config / result serialization tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #19.

## Summary

- ``_build_command`` and ``_build_monomer_command`` gain a ``force: bool = False`` parameter; when ``True``, the returned CLI appends ``--override``.
- ``predict_complex`` and ``predict_monomer`` forward their existing ``force`` kwarg through.
- Zero behavioural change when ``force=False``.

## Why

``Boltz2Runner.predict_complex(..., force=True)`` already bypasses the biolab-runners cache check (``_load_cached_prediction``). The problem was downstream: the CLI command it then ran did not include Boltz-2's ``--override`` flag. ``boltz predict`` silently exits in <5 s when ``--out_dir`` contains prior predictions, so the supposed ""force re-run"" was a no-op — the input YAML got rewritten, but the predicted PDBs stayed stale.

Surfaced against OralBiome-AMP after landing #17 / #18: regenerating Aib peptide structures with the new ``modifications`` YAML block left the old UNK-containing PDBs on disk. Worked around by deleting ``<out>/.../boltz2/output`` manually — this PR removes the workaround.

## Test plan

- [x] ``make validate`` — ruff + pyright + complexipy + pytest green (81/81, +6 new).
- [x] ``TestForceOverride::test_complex_force_false_no_override`` + ``*_default_is_false`` — backwards compat.
- [x] ``TestForceOverride::test_complex_force_true_appends_override`` — exactly one ``--override``.
- [x] ``TestForceOverride::test_monomer_force_true_appends_override`` + inverse.
- [x] ``TestForceOverride::test_predict_complex_threads_force_through`` — end-to-end: patches subprocess, calls ``predict_complex(force=True)``, asserts ``--override`` is in the actually-invoked argv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)