### PR TITLE
test(openmm): implement Flavor B live-OpenMM regression for #174

### DIFF
--- a/biolab_runners/openmm/runner.py
+++ b/biolab_runners/openmm/runner.py
@@ -1145,6 +1145,23 @@ class OpenMMRunner:
         steps_box = [0]
         self._install_sigterm_handler(simulation, state_xml_path, steps_box, config)
 
+        gates_active = enable_early_abort and ref_pep_ca is not None
+        gate_args = {
+            "simulation": simulation,
+            "ref_pep_ca": ref_pep_ca,
+            "ref_pep_ca_idx": ref_pep_ca_idx,
+            "ref_rec_ca": ref_rec_ca,
+            "ref_rec_ca_idx": ref_rec_ca_idx,
+            "abort_thresh": abort_thresh,
+            "irmsd_thresh": irmsd_thresh,
+            "abort_step_5ns": abort_step_5ns,
+            "abort_step_10ns": abort_step_10ns,
+            "config": config,
+            "output_dir": output_dir,
+            "unit": unit,
+            "np": np,
+        }
+
         while steps_box[0] < remaining_steps:
             steps_done = steps_box[0]
             chunk = min(SUB_CHUNK_STEPS, remaining_steps - steps_done)
@@ -1152,78 +1169,36 @@ class OpenMMRunner:
             steps_done += chunk
             steps_box[0] = steps_done
 
-            do_5ns = (
-                enable_early_abort
-                and not early_abort_done
-                and ref_pep_ca is not None
-                and steps_done >= abort_step_5ns
+            early_abort_done, rmsd_5ns, abort_reason = self._maybe_run_5ns_gate(
+                early_abort_done=early_abort_done,
+                rmsd_5ns=rmsd_5ns,
+                rmsd_samples=rmsd_samples,
+                gates_active=gates_active,
+                steps_done=steps_done,
+                **gate_args,
             )
-            if do_5ns:
-                early_abort_done = True
-                rmsd_5ns, aborted = self._do_5ns_check(
-                    simulation,
-                    ref_pep_ca,
-                    ref_pep_ca_idx,
-                    ref_rec_ca,
-                    ref_rec_ca_idx,
-                    abort_thresh,
-                    irmsd_thresh,
-                    config,
-                    steps_done,
-                    output_dir,
-                    unit,
-                    np,
-                )
-                if aborted:
-                    abort_reason = "early_dissociation"
-                    break
-                if rmsd_5ns is not None:
-                    rmsd_samples.append((steps_done * config.timestep_fs / 1e6, rmsd_5ns))
+            if abort_reason:
+                break
 
-            in_slope_window = (
-                enable_early_abort
-                and not slope_check_done
-                and rmsd_5ns is not None
-                and ref_pep_ca is not None
-                and abort_step_5ns < steps_done < abort_step_10ns
+            self._maybe_sample_slope(
+                rmsd_5ns=rmsd_5ns,
+                rmsd_samples=rmsd_samples,
+                slope_check_done=slope_check_done,
+                gates_active=gates_active,
+                steps_done=steps_done,
+                **gate_args,
             )
-            if in_slope_window:
-                sample_rmsd = OpenMMRunner._peptide_ca_rmsd(
-                    simulation,
-                    ref_pep_ca,
-                    ref_pep_ca_idx,
-                    ref_rec_ca,
-                    ref_rec_ca_idx,
-                    unit,
-                    np,
-                )
-                rmsd_samples.append((steps_done * config.timestep_fs / 1e6, sample_rmsd))
 
-            do_10ns = (
-                enable_early_abort
-                and not slope_check_done
-                and rmsd_5ns is not None
-                and ref_pep_ca is not None
-                and steps_done >= abort_step_10ns
+            slope_check_done, abort_reason = self._maybe_run_10ns_gate(
+                rmsd_5ns=rmsd_5ns,
+                rmsd_samples=rmsd_samples,
+                slope_check_done=slope_check_done,
+                gates_active=gates_active,
+                steps_done=steps_done,
+                **gate_args,
             )
-            if do_10ns:
-                slope_check_done = True
-                if self._check_slope_10ns(
-                    simulation,
-                    ref_pep_ca,
-                    ref_pep_ca_idx,
-                    ref_rec_ca,
-                    ref_rec_ca_idx,
-                    rmsd_samples,
-                    abort_thresh,
-                    config,
-                    steps_done,
-                    output_dir,
-                    unit,
-                    np,
-                ):
-                    abort_reason = "rmsd_slope_drift"
-                    break
+            if abort_reason:
+                break
 
             last_ckpt_step = self._maybe_checkpoint(
                 simulation,
@@ -1236,6 +1211,145 @@ class OpenMMRunner:
             )
 
         return steps_box[0], abort_reason
+
+    def _maybe_run_5ns_gate(
+        self,
+        *,
+        early_abort_done: bool,
+        rmsd_5ns: float | None,
+        rmsd_samples: list[tuple[float, float]],
+        gates_active: bool,
+        steps_done: int,
+        simulation: object,
+        ref_pep_ca: object,
+        ref_pep_ca_idx: list[int],
+        ref_rec_ca: object,
+        ref_rec_ca_idx: list[int],
+        abort_thresh: float,
+        irmsd_thresh: float,
+        abort_step_5ns: int,
+        abort_step_10ns: int,  # noqa: ARG002 — unified gate_args
+        config: OpenMMConfig,
+        output_dir: Path,
+        unit: object,
+        np: object,
+    ) -> tuple[bool, float | None, str]:
+        """Run the 5 ns gate if due.
+
+        Returns:
+            ``(early_abort_done, rmsd_5ns, abort_reason)`` — ``abort_reason``
+            is ``""`` unless dissociation was detected.
+        """
+        if not gates_active or early_abort_done or steps_done < abort_step_5ns:
+            return early_abort_done, rmsd_5ns, ""
+        new_rmsd, aborted = self._do_5ns_check(
+            simulation,
+            ref_pep_ca,
+            ref_pep_ca_idx,
+            ref_rec_ca,
+            ref_rec_ca_idx,
+            abort_thresh,
+            irmsd_thresh,
+            config,
+            steps_done,
+            output_dir,
+            unit,
+            np,
+        )
+        if aborted:
+            return True, new_rmsd, "early_dissociation"
+        if new_rmsd is not None:
+            rmsd_samples.append((steps_done * config.timestep_fs / 1e6, new_rmsd))
+        return True, new_rmsd, ""
+
+    @staticmethod
+    def _maybe_sample_slope(
+        *,
+        rmsd_5ns: float | None,
+        rmsd_samples: list[tuple[float, float]],
+        slope_check_done: bool,
+        gates_active: bool,
+        steps_done: int,
+        simulation: object,
+        ref_pep_ca: object,
+        ref_pep_ca_idx: list[int],
+        ref_rec_ca: object,
+        ref_rec_ca_idx: list[int],
+        abort_thresh: float,  # noqa: ARG004 — unified gate_args
+        irmsd_thresh: float,  # noqa: ARG004
+        abort_step_5ns: int,
+        abort_step_10ns: int,
+        config: OpenMMConfig,
+        output_dir: Path,  # noqa: ARG004
+        unit: object,
+        np: object,
+    ) -> None:
+        """Append a slope sample if steps_done is inside the 5–10 ns sampling window."""
+        in_window = (
+            gates_active
+            and rmsd_5ns is not None
+            and not slope_check_done
+            and abort_step_5ns < steps_done < abort_step_10ns
+        )
+        if not in_window:
+            return
+        sample_rmsd = OpenMMRunner._peptide_ca_rmsd(
+            simulation,
+            ref_pep_ca,
+            ref_pep_ca_idx,
+            ref_rec_ca,
+            ref_rec_ca_idx,
+            unit,
+            np,
+        )
+        rmsd_samples.append((steps_done * config.timestep_fs / 1e6, sample_rmsd))
+
+    def _maybe_run_10ns_gate(
+        self,
+        *,
+        rmsd_5ns: float | None,
+        rmsd_samples: list[tuple[float, float]],
+        slope_check_done: bool,
+        gates_active: bool,
+        steps_done: int,
+        simulation: object,
+        ref_pep_ca: object,
+        ref_pep_ca_idx: list[int],
+        ref_rec_ca: object,
+        ref_rec_ca_idx: list[int],
+        abort_thresh: float,
+        irmsd_thresh: float,  # noqa: ARG002 — unified gate_args
+        abort_step_5ns: int,  # noqa: ARG002
+        abort_step_10ns: int,
+        config: OpenMMConfig,
+        output_dir: Path,
+        unit: object,
+        np: object,
+    ) -> tuple[bool, str]:
+        """Run the 10 ns slope gate if due. Returns (slope_check_done, abort_reason)."""
+        due = (
+            gates_active
+            and rmsd_5ns is not None
+            and not slope_check_done
+            and steps_done >= abort_step_10ns
+        )
+        if not due:
+            return slope_check_done, ""
+        drifted = self._check_slope_10ns(
+            simulation,
+            ref_pep_ca,
+            ref_pep_ca_idx,
+            ref_rec_ca,
+            ref_rec_ca_idx,
+            rmsd_samples,
+            abort_thresh,
+            config,
+            steps_done,
+            output_dir,
+            unit,
+            np,
+        )
+        return True, ("rmsd_slope_drift" if drifted else "")
 
     @staticmethod
     def _install_sigterm_handler(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest-cov",
     "complexipy>=0.8",
     "numpy>=1.26",  # required by the OpenMM runner Kabsch-aligned RMSD tests
+    "mdtraj>=1.10",  # required by the Flavor B live-OpenMM `-m slow` regression test
 ]
 
 [build-system]

--- a/tests/test_openmm_runner.py
+++ b/tests/test_openmm_runner.py
@@ -1132,40 +1132,198 @@ class TestOnlineGateMatchesOfflineOnLiveSimulation:
     to write a different coordinate convention) would still pass the
     structural tests but fail here.
 
-    Marked ``@pytest.mark.slow`` because it runs ~100 ps of real MD.
-    Expected runtime: ~5 s on a local GPU (CPU: ~30 s).
+    Marked ``@pytest.mark.slow``: runs a short live MD (~5 ps production
+    on a ~3 nm cubic TIP3P box). Expected runtime: ~20 s on CPU, faster
+    on GPU. Requires the ``openmm`` extra plus ``mdtraj`` (dev group).
     """
 
-    @pytest.mark.slow
-    @pytest.mark.skip(reason="Flavor B placeholder — implement with a 2-chain PDB fixture")
-    def test_online_gate_rmsd_matches_mdtraj_within_half_angstrom(self, tmp_path) -> None:  # noqa: ARG002
-        """Live-OpenMM regression for OralBiome-AMP#174 (Flavor B placeholder).
+    @staticmethod
+    def _build_2chain_ala_modeller(app: object, unit: object, n_a: int, n_b: int, sep_y: float):
+        """Build a 2-chain extended-Ala complex as an OpenMM Modeller.
 
-        Structural Flavor A tests (``TestEnforcePeriodicBoxRegression``)
-        pin the mechanism — every ``getState`` in gate paths must use
-        ``enforcePeriodicBox=True`` and ``_peptide_ca_rmsd`` must not call
-        ``_pbc_correct``. This test additionally pins that those choices
-        actually produce coordinates matching what ``DCDReporter`` writes
-        under the current OpenMM version — the failure surface Flavor A
-        cannot cover because it never calls OpenMM.
-
-        Implementation outline for the follow-up:
-          1. Build a 2-chain complex (two 6–8 residue polyalanine helices
-             placed 8 Å apart) via PDBFixer, OR load a checked-in fixture
-             from ``tests/data/pbc_regression.pdb``.
-          2. Solvate in a small TIP3P cubic box (~3–4 nm) via Modeller.
-          3. Minimize, briefly equilibrate with Cα restraints, run ~50 ps
-             production with DCDReporter on CPU platform (frame every 5 ps).
-          4. During production, at each DCD write, call
-             ``OpenMMRunner._peptide_ca_rmsd`` and record online RMSD.
-          5. After production, load DCD with mdtraj, slice to solute,
-             ``traj.superpose(traj, frame=0, atom_indices=rec_ca)``,
-             compute peptide RMSD per frame.
-          6. Assert ``abs(online[f] - offline[f]) < 0.5`` Å for every
-             recorded frame f.
-
-        Expected runtime: ~5 s GPU, ~30 s CPU. ``@pytest.mark.slow`` gates
-        it out of fast CI; run in nightly or pre-release.
-
-        Follow-up tracked in OralBiome-AMP#174.
+        Heavy atoms only (N, CA, C, O, CB); ``Modeller.addHydrogens`` on the
+        caller adds missing hydrogens and caps N/C termini via the force
+        field's residue templates. Geometry is approximate — minimization
+        reshapes it. Positions are returned in nanometers.
         """
+        from openmm.unit import Quantity
+
+        from openmm import Vec3  # local import — openmm is importorskip'd in the test
+
+        topology = app.Topology()  # type: ignore[attr-defined]
+        positions_bare: list[object] = []
+
+        # Heavy-atom offsets from residue origin (Å); chosen so adjacent
+        # residues stacked at Δx=3.5 Å give a plausible extended backbone
+        # that the CHARMM36 minimizer can relax without exploding.
+        ala_offsets = [
+            ("N", "N", (0.000, 0.000, 0.000)),
+            ("CA", "C", (1.458, 0.500, 0.000)),
+            ("C", "C", (2.478, 0.000, 1.100)),
+            ("O", "O", (2.478, -1.200, 1.100)),
+            ("CB", "C", (1.458, 1.500, -1.200)),
+        ]
+        # C-terminal requires OXT for the CHARMM36 C-term ALA template to match.
+        oxt_offset = ("OXT", "O", (3.478, 0.500, 1.400))
+
+        def _add_chain(chain_id: str, n_res: int, y_off: float) -> None:
+            chain = topology.addChain(chain_id)  # type: ignore[attr-defined]
+            prev_c = None
+            for i in range(n_res):
+                residue = topology.addResidue("ALA", chain)  # type: ignore[attr-defined]
+                atoms_in_res: dict[str, object] = {}
+                x_base = 3.5 * i
+                atom_defs = list(ala_offsets)
+                if i == n_res - 1:
+                    atom_defs.append(oxt_offset)
+                for name, elt_symbol, (dx, dy, dz) in atom_defs:
+                    atom = topology.addAtom(  # type: ignore[attr-defined]
+                        name,
+                        app.Element.getBySymbol(elt_symbol),  # type: ignore[attr-defined]
+                        residue,
+                    )
+                    atoms_in_res[name] = atom
+                    # Convert Å → nm for OpenMM positions (bare Vec3, wrapped
+                    # once as a single Quantity at the end — per-element Quantity
+                    # wrappers break Modeller.addHydrogens under OpenMM 8.5).
+                    positions_bare.append(
+                        Vec3(  # type: ignore[call-arg]
+                            (x_base + dx) * 0.1,
+                            (y_off + dy) * 0.1,
+                            dz * 0.1,
+                        )
+                    )
+                topology.addBond(atoms_in_res["N"], atoms_in_res["CA"])  # type: ignore[attr-defined]
+                topology.addBond(atoms_in_res["CA"], atoms_in_res["C"])  # type: ignore[attr-defined]
+                topology.addBond(atoms_in_res["CA"], atoms_in_res["CB"])  # type: ignore[attr-defined]
+                topology.addBond(atoms_in_res["C"], atoms_in_res["O"])  # type: ignore[attr-defined]
+                if "OXT" in atoms_in_res:
+                    topology.addBond(atoms_in_res["C"], atoms_in_res["OXT"])  # type: ignore[attr-defined]
+                if prev_c is not None:
+                    topology.addBond(prev_c, atoms_in_res["N"])  # type: ignore[attr-defined]
+                prev_c = atoms_in_res["C"]
+
+        _add_chain("A", n_a, y_off=0.0)
+        _add_chain("B", n_b, y_off=sep_y)
+        positions = Quantity(positions_bare, unit.nanometer)  # type: ignore[attr-defined]
+        return app.Modeller(topology, positions)  # type: ignore[attr-defined]
+
+    @pytest.mark.slow
+    def test_online_gate_rmsd_matches_mdtraj_within_half_angstrom(self, tmp_path) -> None:
+        """Live-OpenMM regression for OralBiome-AMP#174.
+
+        Runs a short live MD simulation and asserts that the online gate
+        RMSD (computed via ``OpenMMRunner._peptide_ca_rmsd`` using
+        ``getState(enforcePeriodicBox=True)``) agrees frame-by-frame with
+        an offline RMSD computed from the DCD trajectory (which also uses
+        ``enforcePeriodicBox=True`` internally).
+
+        Flavor A tests (``TestEnforcePeriodicBoxRegression``) pin the
+        **mechanism** — every gate-path ``getState`` passes
+        ``enforcePeriodicBox=True`` and ``_peptide_ca_rmsd`` no longer
+        calls ``_pbc_correct``. This Flavor B test additionally pins that
+        those choices actually produce coordinates matching what
+        ``DCDReporter`` writes under the current OpenMM version — the
+        failure surface Flavor A cannot cover because it never exercises
+        OpenMM itself.
+
+        Expected runtime: ~5–15 s GPU, ~60 s CPU. Gated behind
+        ``@pytest.mark.slow``; run with ``pytest -m slow``.
+        """
+        openmm = pytest.importorskip("openmm")
+        app = pytest.importorskip("openmm.app")
+        unit = pytest.importorskip("openmm.unit")
+        md = pytest.importorskip("mdtraj")
+        import numpy as _np
+
+        # Build a 2-chain Ala complex programmatically ----------------------
+        modeller = self._build_2chain_ala_modeller(app, unit, n_a=5, n_b=4, sep_y=9.0)
+
+        # Solvate in a small cubic box to force PBC exposure ----------------
+        ff = app.ForceField("charmm36.xml", "charmm36/water.xml")
+        modeller.addHydrogens(ff, pH=7.0)
+        modeller.addSolvent(
+            ff,
+            model="tip3p",
+            padding=0.8 * unit.nanometers,
+            boxShape="cube",
+            ionicStrength=0.15 * unit.molar,
+        )
+
+        system = ff.createSystem(
+            modeller.topology,
+            nonbondedMethod=app.PME,
+            nonbondedCutoff=1.0 * unit.nanometers,
+            constraints=app.HBonds,
+        )
+        integrator = openmm.LangevinMiddleIntegrator(
+            310.0 * unit.kelvin,
+            1.0 / unit.picosecond,
+            2.0 * unit.femtoseconds,
+        )
+        # CPU-safe platform — test must not require GPU.
+        platform = openmm.Platform.getPlatformByName("CPU")
+        sim = app.Simulation(modeller.topology, system, integrator, platform)
+        sim.context.setPositions(modeller.positions)
+
+        sim.minimizeEnergy(maxIterations=200)
+        sim.context.setVelocitiesToTemperature(310.0 * unit.kelvin)
+        sim.step(500)  # 1 ps equilibration
+
+        # Reference Cα arrays for online + offline ---------------------------
+        atoms = list(modeller.topology.atoms())
+        rec_ca_idx = [a.index for a in atoms if a.residue.chain.id == "A" and a.name == "CA"]
+        pep_ca_idx = [a.index for a in atoms if a.residue.chain.id == "B" and a.name == "CA"]
+        assert len(rec_ca_idx) >= 3, "Receptor Cα set must be non-degenerate for Kabsch fit"
+        assert len(pep_ca_idx) >= 2, "Peptide Cα set must have at least 2 atoms"
+
+        state0 = sim.context.getState(getPositions=True, enforcePeriodicBox=True)
+        pos0_ang = state0.getPositions(asNumpy=True).value_in_unit(unit.angstroms)
+        ref_rec_ca = _np.asarray(pos0_ang)[rec_ca_idx]
+        ref_pep_ca = _np.asarray(pos0_ang)[pep_ca_idx]
+
+        # Persist reference PDB for mdtraj topology
+        topo_path = tmp_path / "topo.pdb"
+        with open(str(topo_path), "w") as f:
+            app.PDBFile.writeFile(modeller.topology, state0.getPositions(), f)
+
+        # Production: step-by-step to capture online RMSD at each DCD write -
+        dcd_path = tmp_path / "prod.dcd"
+        steps_per_frame = 250  # 0.5 ps
+        n_frames = 10  # 5 ps total
+        sim.reporters.append(
+            app.DCDReporter(str(dcd_path), steps_per_frame, enforcePeriodicBox=True)
+        )
+
+        online_rmsd: list[float] = []
+        for _ in range(n_frames):
+            sim.step(steps_per_frame)
+            r = OpenMMRunner._peptide_ca_rmsd(  # noqa: SLF001
+                sim, ref_pep_ca, pep_ca_idx, ref_rec_ca, rec_ca_idx, unit, _np
+            )
+            online_rmsd.append(r)
+
+        # Release the DCD so mdtraj can read it
+        sim.reporters.clear()
+        del sim
+
+        # Offline RMSD via mdtraj --------------------------------------------
+        traj = md.load(str(dcd_path), top=str(topo_path))
+        ref_traj = md.load(str(topo_path))
+        rec_idx_arr = _np.asarray(rec_ca_idx, dtype=_np.int64)
+        pep_idx_arr = _np.asarray(pep_ca_idx, dtype=_np.int64)
+        traj.superpose(ref_traj, atom_indices=rec_idx_arr)
+        pep_diff_nm = traj.xyz[:, pep_idx_arr, :] - ref_traj.xyz[0, pep_idx_arr, :]
+        offline_rmsd = _np.sqrt((pep_diff_nm**2).sum(axis=-1).mean(axis=-1)) * 10.0
+
+        assert len(online_rmsd) == len(offline_rmsd), (
+            f"Frame count mismatch: online={len(online_rmsd)}, offline={len(offline_rmsd)}. "
+            "DCDReporter should produce exactly one frame per step-block."
+        )
+        for i, (on, off) in enumerate(zip(online_rmsd, offline_rmsd, strict=True)):
+            assert abs(on - off) < 0.5, (
+                f"Frame {i}: online RMSD = {on:.3f} Å, offline RMSD = {off:.3f} Å, "
+                f"|diff| = {abs(on - off):.3f} Å ≥ 0.5 Å. If this fails, the "
+                "online gate and DCD are reporting different coordinate systems "
+                "— likely an OpenMM API/semantics regression on enforcePeriodicBox=True."
+            )


### PR DESCRIPTION
## Summary

- Implements the `TestOnlineGateMatchesOfflineOnLiveSimulation` placeholder from PR #25 with a working live-MD integration test that exercises `OpenMMRunner._peptide_ca_rmsd` against `DCDReporter` output on a real short MD simulation.
- Catches the one failure surface Flavor A structural tests cannot: a future OpenMM version or config change that keeps `enforcePeriodicBox=True` syntactically present but silently breaks its semantics, causing the online gate's RMSD to diverge from the DCD coords.
- Adds `mdtraj>=1.10` to the `dev` dependency group (used by the test to compute the offline receptor-Cα-aligned reference RMSD).
- Bundles an unrelated-but-blocking complexity fix: `_run_production_loop` had drifted to cognitive complexity 19 after PRs #22/#23, silently failing `make validate` on main since `complexipy` is only enforced locally, not in CI. Split into three small gate helpers; complexity now 19 → 6.

## Test design

The integration test (OralBiome-AMP#174, Flavor B):

1. Programmatically builds a 2-chain extended-Ala complex (5 residues + 4 residues, heavy atoms only) via `app.Topology`.
2. Adds hydrogens + solvates in a ~3 nm cubic TIP3P box with 150 mM NaCl using the CHARMM36 force field.
3. Minimizes + runs a 1 ps equilibration.
4. Captures reference receptor-Cα and peptide-Cα positions from `getState(enforcePeriodicBox=True)`.
5. Runs ~5 ps production with `DCDReporter(enforcePeriodicBox=True)`, stepping in 0.5 ps sub-chunks. At each sub-chunk, calls `OpenMMRunner._peptide_ca_rmsd` (online, Kabsch on receptor-Cα, `getState(enforcePeriodicBox=True)`) and records the RMSD.
6. Reloads the DCD with mdtraj, `traj.superpose(ref_traj, atom_indices=rec_ca)`, computes offline peptide-Cα RMSD per frame.
7. Asserts `abs(online[f] - offline[f]) < 0.5` Å for every frame.

Runs on CPU in ~20 s. Gated behind `@pytest.mark.slow`.

## Complexity refactor (bundled)

`_run_production_loop` went from complexity 13 (pre-PR #22) → 19 (post-PR #23), exceeding the project's `--max-complexity-allowed 15` ceiling. CI missed it because `.github/workflows/ci.yml` runs `ruff + pyright + pytest` but not `complexipy`. Local `make validate` has been failing on main since PR #23 merged.

Extracted three phase helpers (`_maybe_run_5ns_gate`, `_maybe_sample_slope`, `_maybe_run_10ns_gate`) that share a unified `gate_args` kwarg dict. Behavior-preserving: all 103 tests pass unchanged, including the Flavor A regression battery from PR #25 and the new Flavor B test.

Follow-up opportunity (not in this PR): add `complexipy` to `.github/workflows/ci.yml` so future drift fails CI, not just local `make validate`.

## Test plan

- [x] `make ruff` passes (format + lint)
- [x] `make check_types` passes (pyright — 0 errors, 0 warnings)
- [x] `make check_complexity` passes (all functions ≤15, previously failing on `_run_production_loop`)
- [x] `make test` passes (103 passed, includes new Flavor B)
- [x] `make validate` passes end-to-end (previously failing on main due to complexity drift)
- [x] `pytest -m slow` specifically: 1 passed (Flavor B runs in 20s CPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)