### PR TITLE
fix: housekeeping — badges, SHA pinning, resume accounting, gitmessage

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,9 @@
     "makefile-core@qte77-claude-code-utils": true,
     "cc-meta@qte77-claude-code-utils": true,
     "workspace-setup@qte77-claude-code-utils": true,
-    "security-audit@qte77-claude-code-utils": true
+    "security-audit@qte77-claude-code-utils": true,
+    "gha-dev@qte77-claude-code-utils": true,
+    "planning@qte77-claude-code-utils": true
   },
   "extraKnownMarketplaces": {
     "qte77-claude-code-utils": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
@@ -14,10 +17,10 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,9 +18,9 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: github/codeql-action/init@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
         with:
           languages: python
-      - uses: github/codeql-action/autobuild@v4
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/autobuild@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
+      - uses: github/codeql-action/analyze@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4

--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -15,8 +15,8 @@ jobs:
   generate-sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: qte77/gha-sbom-action@v0.1.0
+      - uses: qte77/gha-sbom-action@cd873b1278a6793a99cfe199c01d603d72cca717 # v0.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,15 +18,15 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v6
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6
         with:
           title: "lychee: broken links detected"
           content-filepath: ./lychee/out.md

--- a/.github/workflows/write-llms-txt.yaml
+++ b/.github/workflows/write-llms-txt.yaml
@@ -17,7 +17,7 @@ jobs:
   write-llms-txt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set BLOB URL
         id: vars

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,38 @@
+#<--- 72 characters --------------------------------------------------->
+#
+# Conventional Commits, semantic commit messages for humans and machines
+# https://www.conventionalcommits.org/en/v1.0.0/
+# Lint your conventional commits
+# https://github.com/conventional-changelog/commitlint/tree/master/%40 \
+#	commitlint/config-conventional
+# Common types can be (based on Angular convention)
+# build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+# https://github.com/conventional-changelog/commitlint/tree/master/%40
+# Footer
+# https://git-scm.com/docs/git-interpret-trailers
+#
+#<--- pattern --------------------------------------------------------->
+#
+# <feat|fix|build|chore|ci|docs|style|refactor|perf|test>[(Scope)][!]: \
+#	<description>
+# short description: <type>[(<scope>)]: <subject>
+#
+# ! after scope in header indicates breaking change
+#
+# [optional body]
+#
+# - with bullets points
+#
+# [optional footer(s)]
+#
+# [BREAKING CHANGE:, Refs:, Resolves:, Addresses:, Reviewed by:]
+#
+#<--- usage ----------------------------------------------------------->
+#
+# Set locally (in the repository)
+# `git config commit.template .gitmessage`
+#
+# Set globally
+# `git config --global commit.template .gitmessage`
+#
+#<--- 72 characters --------------------------------------------------->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,19 +4,11 @@ This is a private repository. All contributions must be authorized.
 
 ## Commit Format
 
-Use [Conventional Commits](https://www.conventionalcommits.org/):
+Use [Conventional Commits](https://www.conventionalcommits.org/). See [`.gitmessage`](.gitmessage) for the template.
 
+```bash
+git config commit.template .gitmessage
 ```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
-```
-
-**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `perf`
-
-**Scopes:** `boltz2`, `openmm`, `config`, `ci`
 
 ## Pre-commit Checklist
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CodeFactor](https://www.codefactor.io/repository/github/lambda-biolab/biolab-runners/badge)](https://www.codefactor.io/repository/github/lambda-biolab/biolab-runners)
 [![CodeQL](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/codeql.yml/badge.svg)](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/codeql.yml)
-[![Dependabot](https://img.shields.io/badge/dependabot-enabled-blue?logo=dependabot)](https://github.com/Lambda-Biolab/biolab-runners/network/updates)
+[![Dependabot Updates](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/dependabot/dependabot-updates)
 
 Standalone, modular Python runners for **Boltz-2 structure prediction** and **OpenMM molecular dynamics simulations**.
 

--- a/biolab_runners/openmm/config.py
+++ b/biolab_runners/openmm/config.py
@@ -170,6 +170,7 @@ class OpenMMConfig:
 
     # Computed fields
     total_steps: int = 0
+    total_equil_steps: int = 0
     save_every_steps: int = 0
     checkpoint_every_steps: int = 0
 
@@ -180,6 +181,12 @@ class OpenMMConfig:
         """Compute derived step counts."""
         steps_per_ps = 1000.0 / self.timestep_fs
         self.total_steps = int(self.production_ns * 1000.0 * steps_per_ps)
+        equil_ps = 0.0
+        for stage in self.equilibration:
+            dur = stage.get("duration_ps")
+            if isinstance(dur, (int, float)):
+                equil_ps += dur
+        self.total_equil_steps = int(equil_ps * steps_per_ps)
         self.save_every_steps = int(self.save_interval_ps * steps_per_ps)
         self.checkpoint_every_steps = int(
             self.checkpoint_interval_hours * 3600.0 * 1000.0 / self.timestep_fs

--- a/biolab_runners/openmm/runner.py
+++ b/biolab_runners/openmm/runner.py
@@ -258,7 +258,8 @@ class OpenMMRunner:
                     start_step * config.timestep_fs / 1e6,
                 )
 
-        remaining_steps = max(0, config.total_steps - start_step)
+        production_steps_done = max(0, start_step - config.total_equil_steps)
+        remaining_steps = max(0, config.total_steps - production_steps_done)
         if remaining_steps == 0:
             logger.info("No remaining steps — simulation already complete")
             result.trajectory_path = str(output_dir / "trajectory.dcd")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ ignore = [
     "D104",  # missing public package docstring
     "D107",  # missing docstring in __init__
     "S101",  # assert used (needed for tests)
-    "S108",  # hardcoded temp paths (/tmp)
     "S603",  # subprocess call — pipeline shells out to boltz CLI
     "S607",  # partial path for subprocess — boltz binary is on PATH
     "S602",  # subprocess shell — not used

--- a/tests/test_openmm_runner.py
+++ b/tests/test_openmm_runner.py
@@ -95,7 +95,7 @@ class TestOpenMMConfig:
         """Default list must be per-instance (no mutable default aliasing)."""
         a = OpenMMConfig()
         b = OpenMMConfig()
-        a.extra_forcefields.append("/tmp/a.xml")
+        a.extra_forcefields.append("custom/a.xml")
         assert b.extra_forcefields == []
 
     def test_extra_forcefields_roundtrip(self, tmp_path: Path) -> None:

--- a/tests/test_openmm_runner.py
+++ b/tests/test_openmm_runner.py
@@ -44,6 +44,11 @@ class TestOpenMMConfig:
         assert config.save_every_steps == 5000  # 10ps * 500 steps/ps
         assert config.checkpoint_every_steps == 3_600_000  # 2hr * 3600s/hr * 500steps/s
 
+    def test_equil_steps_computation(self) -> None:
+        config = OpenMMConfig(timestep_fs=2.0)
+        # Default: 100ps + 100ps + 200ps = 400ps at 500 steps/ps = 200_000
+        assert config.total_equil_steps == 200_000
+
     def test_custom_production_ns(self) -> None:
         config = OpenMMConfig(production_ns=20.0, timestep_fs=2.0)
         assert config.total_steps == 10_000_000
@@ -383,6 +388,48 @@ class TestOpenMMRunner:
 # ---------------------------------------------------------------------------
 # iRMSD threshold tests
 # ---------------------------------------------------------------------------
+
+
+class TestResumeAccounting:
+    """Regression tests for issue #4: resume must not conflate equilibration + production."""
+
+    def test_resume_subtracts_equil_steps(self, tmp_path: Path) -> None:
+        """Remaining steps must discount equilibration from the checkpoint step counter."""
+        out = tmp_path / "output"
+        out.mkdir()
+
+        config = OpenMMConfig(output_dir=str(out), production_ns=100.0, timestep_fs=2.0)
+        # Simulate checkpoint after full equil (200k steps) + 1 ns production (500k steps)
+        checkpoint_step = config.total_equil_steps + 500_000
+        (out / "energy.csv").write_text(f"#step,time\n{checkpoint_step},{checkpoint_step}\n")
+        (out / "state.xml").write_text("<State/>")
+
+        runner = OpenMMRunner(config)
+        resume = runner._resolve_skip_or_resume(
+            force=False, output_dir=out, config=config, result=SimulationResult(config=config)
+        )
+        assert resume is not None
+        _start_step, remaining_steps, _resume_xml = resume
+        # Should be total_steps minus production-only steps done (500k), not minus absolute (700k)
+        assert remaining_steps == config.total_steps - 500_000
+
+    def test_resume_right_after_equil(self, tmp_path: Path) -> None:
+        """Checkpoint at end of equilibration should leave all production steps remaining."""
+        out = tmp_path / "output"
+        out.mkdir()
+
+        config = OpenMMConfig(output_dir=str(out), production_ns=100.0, timestep_fs=2.0)
+        checkpoint_step = config.total_equil_steps  # just finished equilibration
+        (out / "energy.csv").write_text(f"#step,time\n{checkpoint_step},{checkpoint_step}\n")
+        (out / "state.xml").write_text("<State/>")
+
+        runner = OpenMMRunner(config)
+        resume = runner._resolve_skip_or_resume(
+            force=False, output_dir=out, config=config, result=SimulationResult(config=config)
+        )
+        assert resume is not None
+        _, remaining_steps, _ = resume
+        assert remaining_steps == config.total_steps
 
 
 class TestIrmsdThreshold:


### PR DESCRIPTION
## Summary

- **fix: update Dependabot badge** — Replace shields.io badge with GitHub Actions workflow badge (closes #14)
- **fix: remove hardcoded /tmp paths** — Replace `/tmp/a.xml` with `custom/a.xml` in tests, remove S108 ruff suppression (CodeFactor B108)
- **ci: pin all actions to SHA** — Comply with repo `sha_pinning_required` setting; add explicit `permissions: read` to ci.yml; bump `qte77/gha-sbom-action` v0.1.0 → v0.1.1
- **docs: .gitmessage template** — Move commit format guidance from CONTRIBUTING.md inline section into a `.gitmessage` template file
- **fix(openmm): resume accounting** — Separate equilibration from production steps in checkpoint resume logic (closes #4)

## Test plan

- [x] `make quick_validate` passes (ruff + pyright)
- [x] Full test suite: 108/108 pass
- [x] New tests: `TestResumeAccounting` (2 tests) + `test_equil_steps_computation`

Generated with Claude <noreply@anthropic.com>