### PR TITLE
fix(boltz2): prefer canonical _model_0.pdb over sibling variants

### DIFF
--- a/biolab_runners/boltz2/utils.py
+++ b/biolab_runners/boltz2/utils.py
@@ -121,8 +121,36 @@ def is_boltz_output_complete(output_dir: Path) -> bool:
 
 
 def _find_structure_file(output_dir: Path) -> str:
-    """Return the first structure file under output_dir, or ""."""
-    for pattern in ["**/predictions/**/*.pdb", "**/*.pdb", "**/*.cif"]:
+    """Return the first structure file under output_dir, or "".
+
+    Prefers the canonical ``*_model_0.pdb`` suffix exactly. Broad
+    fallback globs (``**/*.pdb``) are consulted only when no canonical
+    file is found, so downstream consumers never silently ingest a
+    sibling file like ``*_model_0.no_caps_backup.pdb`` or
+    ``*_model_0_preminimize.pdb``. Those sibling files sort before the
+    canonical ``_model_0.pdb`` in a naive alphabetical glob
+    (``n`` < ``p`` in ASCII), which previously caused OralBiome-AMP's
+    MD stage to re-extract the peptide chain from a pre-cap backup
+    after the cohort had been re-predicted with the correct caps —
+    producing silently-wrong-molecule Stage-2 verdicts.
+
+    Search order:
+
+    1. ``**/*_model_0.pdb`` — Boltz-2's canonical output, two layouts:
+       flat ``{name}_model_0.pdb`` and the older
+       ``boltz_results_<name>/predictions/<name>/<name>_model_0.pdb``.
+    2. ``**/predictions/**/*.pdb`` — any PDB inside a ``predictions/``
+       subtree; used for non-standard dumps that still follow the
+       Boltz directory convention.
+    3. ``**/*.pdb`` — permissive fallback.
+    4. ``**/*.cif`` — when Boltz-2 ran with ``--output_format mmcif``.
+    """
+    for pattern in [
+        "**/*_model_0.pdb",
+        "**/predictions/**/*.pdb",
+        "**/*.pdb",
+        "**/*.cif",
+    ]:
         matches = sorted(output_dir.glob(pattern))
         if matches:
             return str(matches[0])

--- a/tests/test_boltz2_runner.py
+++ b/tests/test_boltz2_runner.py
@@ -574,3 +574,64 @@ class TestSerialization:
         assert config.use_potentials is True
         assert config.timeout_seconds == 1800
         assert config.boltz_binary == "boltz"
+
+
+class TestFindStructureFilePrefersCanonical:
+    """Regression: ``_find_structure_file`` must prefer ``*_model_0.pdb`` over
+    sibling files like ``*_model_0.no_caps_backup.pdb`` or
+    ``*_model_0_preminimize.pdb`` that sort alphabetically earlier.
+
+    Before the fix, a downstream MD stage that re-predicts with corrected
+    caps (e.g. after a cap-gap bugfix landed the canonical ``_model_0.pdb``
+    file) would silently ingest the stale backup and run MD on the wrong
+    molecule. Observed 2026-04-24 on the VicK gen-3 cyclic cohort.
+    """
+
+    def test_prefers_canonical_over_no_caps_backup(self, tmp_path: Path) -> None:
+        from biolab_runners.boltz2.utils import _find_structure_file
+
+        canonical = tmp_path / "vick_lin_01_model_0.pdb"
+        backup = tmp_path / "vick_lin_01_model_0.no_caps_backup.pdb"
+        canonical.write_text("ATOM  CANONICAL\nEND\n")
+        backup.write_text("ATOM  BACKUP\nEND\n")
+        # Alphabetical order puts backup first; the fix must override that.
+        assert _find_structure_file(tmp_path) == str(canonical)
+
+    def test_prefers_canonical_over_preminimize(self, tmp_path: Path) -> None:
+        from biolab_runners.boltz2.utils import _find_structure_file
+
+        canonical = tmp_path / "vick_lac_07_model_0.pdb"
+        preminimize = tmp_path / "vick_lac_07_model_0_preminimize.pdb"
+        canonical.write_text("ATOM  CANONICAL\nEND\n")
+        preminimize.write_text("ATOM  PREMINIMIZE\nEND\n")
+        assert _find_structure_file(tmp_path) == str(canonical)
+
+    def test_nested_predictions_layout_still_resolves(self, tmp_path: Path) -> None:
+        """The older ``boltz_results_*/predictions/*/`` layout still works."""
+        from biolab_runners.boltz2.utils import _find_structure_file
+
+        nested = tmp_path / "boltz_results_input" / "predictions" / "input"
+        nested.mkdir(parents=True)
+        canonical = nested / "input_model_0.pdb"
+        canonical.write_text("ATOM  NESTED\nEND\n")
+        assert _find_structure_file(tmp_path) == str(canonical)
+
+    def test_falls_back_when_no_canonical(self, tmp_path: Path) -> None:
+        """If the canonical suffix is absent, the broad glob still matches."""
+        from biolab_runners.boltz2.utils import _find_structure_file
+
+        other = tmp_path / "vick_lin_01_refined.pdb"
+        other.write_text("ATOM  OTHER\nEND\n")
+        assert _find_structure_file(tmp_path) == str(other)
+
+    def test_falls_back_to_cif_when_only_mmcif_present(self, tmp_path: Path) -> None:
+        from biolab_runners.boltz2.utils import _find_structure_file
+
+        cif = tmp_path / "vick_lin_01_model_0.cif"
+        cif.write_text("_atom_site\n")
+        assert _find_structure_file(tmp_path) == str(cif)
+
+    def test_empty_dir_returns_empty_string(self, tmp_path: Path) -> None:
+        from biolab_runners.boltz2.utils import _find_structure_file
+
+        assert _find_structure_file(tmp_path) == ""


### PR DESCRIPTION
## Summary

\`_find_structure_file\` globbed \`**/*.pdb\` and returned \`matches[0]\` alphabetically. Sibling files whose names sort before the canonical \`_model_0.pdb\` were silently preferred.

## Real-world impact

OralBiome-AMP VicK gen-3 cyclic cohort (2026-04-24): after a cap-propagation bug was fixed (closes #233 in OralBiome-AMP) and the cohort re-predicted with correct ACE/NME caps, a stale \`*_model_0.no_caps_backup.pdb\` file left on disk from an earlier ad-hoc session was preferred by this glob (\`n\` < \`p\` in ASCII). MD re-extracted chain B from the stale backup → Stage-2 verdicts run on uncapped zwitterions instead of the designed Ac-/-NH₂ peptides.

Same hazard applies to \`*_model_0_preminimize.pdb\` (pre-clash-repair pose) whenever a canonical file coexists.

## Fix

Add the canonical suffix \`**/*_model_0.pdb\` as the first pattern in the search order. Fall back to the existing permissive globs only when no canonical file is found.

\`\`\`python
for pattern in [
    \"**/*_model_0.pdb\",              # NEW — canonical suffix
    \"**/predictions/**/*.pdb\",
    \"**/*.pdb\",
    \"**/*.cif\",
]:
\`\`\`

Nested \`boltz_results_*/predictions/*/\` layout still resolves correctly because the canonical filename ends in \`_model_0.pdb\` in both layouts.

## Test plan

- [x] 6 new regression tests in \`TestFindStructureFilePrefersCanonical\`: canonical beats \`.no_caps_backup.pdb\` + beats \`_preminimize.pdb\` + nested layout resolves + broad fallback works + mmCIF fallback preserved + empty dir returns empty
- [x] Full suite: 97 passed, 1 skipped

## Downstream

After merge, OralBiome-AMP bumps its biolab-runners pin and re-runs the 3 affected candidates that are still in flight (\`lin_03\`, \`lac_04\`, \`lac_06\`). Local stale \`.no_caps_backup.pdb\` files have already been deleted there as an interim mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)