### PR TITLE
docs(readme): adopt 7-badge order pinned to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # biolab-runners
 
-[![CodeFactor](https://www.codefactor.io/repository/github/lambda-biolab/biolab-runners/badge)](https://www.codefactor.io/repository/github/lambda-biolab/biolab-runners)
-[![CodeQL](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/codeql.yml/badge.svg)](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/codeql.yml)
-[![Dependabot Updates](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/dependabot/dependabot-updates)
+[![Version](https://img.shields.io/badge/version-0.1.0-8A2BE2)](pyproject.toml)
+[![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+[![Tests](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/ci.yml)
+[![Lint](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/ci.yml)
+[![Dependabot Updates](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/dependabot/dependabot-updates/badge.svg?branch=main)](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/dependabot/dependabot-updates)
+[![CodeQL](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/Lambda-Biolab/biolab-runners/actions/workflows/codeql.yml)
+[![CodeFactor](https://www.codefactor.io/repository/github/lambda-biolab/biolab-runners/badge/main)](https://www.codefactor.io/repository/github/lambda-biolab/biolab-runners)
 
 Standalone, modular Python runners for **Boltz-2 structure prediction** and **OpenMM molecular dynamics simulations**.
 


### PR DESCRIPTION
## Summary

- Replaces the existing 3-badge block (CodeFactor, CodeQL, Dependabot Updates) with the locked 7-badge order: **Version, License, Tests, Lint, Dependabot Updates, CodeQL, CodeFactor**
- All CI-derived badges pinned to `?branch=main` (and `/badge/main` for CodeFactor)
- Version pulled from `pyproject.toml` (0.1.0); License set to **MIT** (matches `pyproject.toml` and `LICENSE` — issue #39 body had Apache-2.0, which was incorrect)
- `Tests` and `Lint` both point at `ci.yml` since the CI workflow runs both jobs together

Addresses the badge half of #39. CodeFactor re-scan after merge will determine whether the 14 findings still apply (per earlier analysis, 11 B108 findings are already resolved by PR #13).

## Test plan

- [ ] CI green on both Python 3.11 and 3.12
- [ ] CodeQL green
- [ ] CodeFactor green
- [ ] Rendered README shows all 7 badges in the specified order
- [ ] All workflow badges report status from `main` (not "no status")

Generated with Claude <noreply@anthropic.com>