### PR TITLE
ci: adopt qte77 newer-style CodeQL + Dependabot baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "python"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,12 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
     - cron: "27 11 * * 0"
   workflow_dispatch:
+
+# DO NOT add `pull_request` — its merge-ref SHA races GitHub's merge-protection check.
 
 jobs:
   analyze:
@@ -23,4 +22,14 @@ jobs:
         with:
           languages: python
       - uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
-      - uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+      - name: Perform CodeQL Analysis
+        id: analyze
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          output: sarif-results
+      - uses: advanced-security/dismiss-alerts@046d6b48d2e43cf563f96f67332c47c432eff83e # v2.0.2
+        with:
+          sarif-id: ${{ steps.analyze.outputs.sarif-id }}
+          sarif-file: sarif-results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #46

## Summary

Adopt the qte77 "newer-style" baseline for CodeQL and Dependabot across the repo.

- **CodeQL** (`.github/workflows/codeql.yml`):
  - Remove `pull_request` trigger (merge-ref SHA races GitHub's merge-protection check)
  - Remove `branches: [main]` filter from `push` — every push gets scanned
  - Add `id: analyze` + `output: sarif-results` to the analyze step
  - Add `advanced-security/dismiss-alerts@v2.0.2` to auto-dismiss alerts for removed code
- **Dependabot** (`.github/dependabot.yml`):
  - Add commit-message prefixes (`chore(deps)` for pip, `chore(ci)` for github-actions)
  - Add labels (`dependencies` + ecosystem-specific)
  - Keep ecosystem as `pip` — no `uv.lock` in this repo

Reference exemplars (do not modify):
- CodeQL: `qte77/Agents-eval`, `qte77/doc-pipeline-engine`
- Dependabot: `qte77/analyze-stock-kpi`

## Trade-off

Dropping the `pull_request` trigger means CodeQL no longer scans pre-merge. Coverage shifts to:
- Every `push` (including merge commits to main)
- Weekly cron `27 11 * * 0`
- Manual `workflow_dispatch`

Per the baseline rationale, this avoids the race between the merge-ref SHA and GitHub's merge-protection check.

## Test plan

- [ ] CI green (lint + tests)
- [ ] CodeQL runs successfully on the merge commit
- [ ] `dismiss-alerts` step succeeds (or fails closed without breaking the workflow)
- [ ] Next Dependabot PR uses `chore(deps): …` / `chore(ci): …` prefix and gets labeled

Generated with Claude <noreply@anthropic.com>