### PR TITLE
chore: add architecture-decision issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture-decision.md
+++ b/.github/ISSUE_TEMPLATE/architecture-decision.md
@@ -1,0 +1,26 @@
+---
+name: Architecture decision (ADR-class)
+about: An architectural decision needing structured discussion + sign-off
+title: 'ADR: '
+labels: ['architecture', 'decision']
+---
+
+<!-- 1-2 paragraph context: why this decision is being made now, what's at stake, what existing work is affected. -->
+
+## Decision
+
+- **A.** <option> — <one-line trade-off>
+- **B.** <option> — <one-line trade-off>
+- **C.** <option> — <one-line trade-off>
+
+## Done when
+
+- [ ] ADR written (in `bioml-commons/decisions/` if cross-cutting, otherwise in the producing repo's `docs/`)
+- [ ] Decision executed (code, schema, or process change landed)
+- [ ] Cross-references updated (sibling issues, downstream consumers)
+
+## Input requested
+
+@qte77 — would value your read on <specific A/B/C question>. Particularly interested in <concrete sub-decision>. Reply inline; closing after YYYY-MM-DD regardless.
+
+Refs: <repo>#<N>, <doc-path>


### PR DESCRIPTION
Drops `.github/ISSUE_TEMPLATE/architecture-decision.md` so ADR-class issues match the shape used in deep-research-pipeline board items A1, A4, A5, R6. Context / Decision A/B/C / Done when / Input requested / Refs. Pure metadata, zero runtime impact.

Refs: Lambda-Biolab/bioml-commons#17 (deep-research-pipeline board north star)